### PR TITLE
Fixed LLVM major version from "10.0" to "10".

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 10
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected


### PR DESCRIPTION
Using MAJOR.MINOR string in Dockerfile.package-cpu crashes due to a numeric comparison made by `scripts/centos_install_llvm.sh`.

This simply set LLVM version from `10.0` to `10`.

~Note: I couldn't find a LLVM released under `10.1.x` (in https://releases.llvm.org/), so I assume the current returned value `10.0.1` is correct.~

Edit: This is moving from 10.0 to 10.