### PR TITLE
Make scripts/patch_name.sh to be compatible with TVM 0.7 and 0.8

### DIFF
--- a/scripts/patch_name.sh
+++ b/scripts/patch_name.sh
@@ -11,5 +11,5 @@ else
     PACKAGE_NAME="tlcpack-cu${CUDA_VERSION/./}"
 fi
 
-sed -i "s/name='tvm'/name='${PACKAGE_NAME}'/g" python/setup.py
+sed -i "s/name=[\"']tvm[\"']/name=\"${PACKAGE_NAME}\"/g" python/setup.py
 sed -i "s/TVM: An End to End Tensor IR\/DSL Stack for Deep Learning Systems/TLCPack: Tensor learning compiler binary distribution/g" python/setup.py


### PR DESCRIPTION
During the migration to `black` formatting in TVM 0.8, the use of double-quotes was adopted, so this script needs to be fixed to cope with both single and double-quotes, during the name patching process.