### PR TITLE
Use $SCRIPT_DIR to infer the location of ../docker and ../pip

### DIFF
--- a/scripts/build_pip_wheel.sh
+++ b/scripts/build_pip_wheel.sh
@@ -5,8 +5,8 @@ set -u
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../docker" && pwd)"
-PIP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../pip" && pwd)"
+DOCKER_DIR="$(dirname "${SCRIPT_DIR}")/docker"
+PIP_DIR="$(dirname "${SCRIPT_DIR}")/pip"
 
 DOCKER_TAG=`cat "${DOCKER_DIR}/version.txt"`
 COMMIT_HASH=`cat "${SCRIPT_DIR}/tvm_commit_hash.txt"`


### PR DESCRIPTION
 Previously it was necessary to create a "pip" directory manually to avoid this script to crash. This was because of the assumption made by the definition of `$PIP_DIR`.

With this change, we assume they will be at the same level as scripts.

Closes #20