### PR TITLE
Update manylinux2010 to a recent version.

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -1,6 +1,6 @@
 # Docker image: tlcpack/package-cpu
 
-FROM quay.io/pypa/manylinux2010_x86_64:2020-08-20-df89e22
+FROM quay.io/pypa/manylinux2010_x86_64:2020-12-15-ba3529a
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh


### PR DESCRIPTION
 The previous version we were using, had some out-of-date repository definitions. Updating to the same manylinux2010 image, from a more recent tag.

The error I see when trying to rebuild the Docker images with the current definition is:
```
$ ./build_image.sh cpu
DOCKER IMAGE NAME: tlcpack/package-cpu:0.1
Sending build context to Docker daemon  31.74kB
Step 1/13 : FROM quay.io/pypa/manylinux2010_x86_64:2020-08-20-df89e22
 ---> 2d0471711e4c
Step 2/13 : COPY install/centos_install_core.sh /install/centos_install_core.sh
 ---> Using cache
 ---> 13c0f0f50547
Step 3/13 : RUN bash /install/centos_install_core.sh
 ---> Running in a143645f3e46
Loaded plugins: fastestmirror, ovl
Setting up Install Process
Determining fastest mirrors
Error: Cannot find a valid baseurl for repo: base
YumRepo Error: All mirror URLs are not using ftp, http[s] or file.
 Eg. Invalid release/repo/arch combination/
removing mirrorlist with no valid mirrors: /var/cache/yum/x86_64/6/base/mirrorlist.txt
The command '/bin/sh -c bash /install/centos_install_core.sh' returned a non-zero code: 1
```