### PR TITLE
Add option to build TVM from a specific repository with --tvm-url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Or, to build wheels for CPU only, run
 ```bash
 ./scripts/build_pip_wheel.sh --cuda none
 ```
+
+Check `./scripts/build_pip_wheel.sh --help` for other options.

--- a/scripts/build_pip_wheel.sh
+++ b/scripts/build_pip_wheel.sh
@@ -10,9 +10,11 @@ PIP_DIR="$(dirname "${SCRIPT_DIR}")/pip"
 
 DOCKER_TAG=`cat "${DOCKER_DIR}/version.txt"`
 COMMIT_HASH=`cat "${SCRIPT_DIR}/tvm_commit_hash.txt"`
+DEFAULT_TVM_URL="https://github.com/apache/tvm"
+TVM_URL="${DEFAULT_TVM_URL}"
 
 function usage() {
-    echo "Usage: $0 [--cuda CUDA] [--hash GIT_HASH]"
+    echo "Usage: $0 [--cuda CUDA] [--tvm-url URL] [--hash GIT_HASH]"
     echo
     echo -e "--cuda {none 10.0 10.1 10.2}"
     echo -e "\tSpecify the CUDA version in building the wheels. If not specified, build all version."
@@ -20,6 +22,10 @@ function usage() {
     echo -e "--hash GIT_HASH"
     echo -e "\tBuild packages using a specific TVM git hash."
     echo -e "\tThis option overrides the value in scripts/tvm_commit_hash.txt"
+    echo
+    echo -e "--tvm-url URL"
+    echo -e "\tBuild packages using a custom TVM repository URL."
+    echo -e "\tDefaults to \"${DEFAULT_TVM_URL}\""
     echo
 }
 
@@ -36,7 +42,7 @@ function in_array() {
 
 function build_wheel() {
     CUDA="$1"
-    ARGS="--hash ${COMMIT_HASH}"
+    ARGS="--tvm-url \"${TVM_URL}\" --hash ${COMMIT_HASH}"
     if [[ ${CUDA} == "none" ]]; then
         DOCKER_IMAGE="tlcpack/package-cpu:${DOCKER_TAG}"
         CUDA_ENV=""
@@ -70,6 +76,10 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             usage
             exit -1
+            ;;
+        --tvm-url)
+            TVM_URL=("$2")
+            shift 2
             ;;
         *) # unknown option
             echo "Unknown argument: $arg"

--- a/scripts/build_tvm.sh
+++ b/scripts/build_tvm.sh
@@ -3,11 +3,14 @@
 source /multibuild/manylinux_utils.sh
 
 function usage() {
-    echo "Usage: $0 [--cuda CUDA] [--hash HASH]"
+    echo "Usage: $0 [--cuda CUDA] [--tvm-url URL] [--hash HASH]"
     echo
     echo -e "--cuda {none 10.0 10.1 10.2}"
     echo -e "\tSpecify the CUDA version in the TVM (default: none)."
-    echo -e "--hash HASH\tSpecify a git commit hash for TVM."
+    echo -e "--hash HASH"
+    echo -e "\tSpecify a git commit hash for TVM."
+    echo -e "--tvm-url URL"
+    echo -e "\tSpecify a git repository URL for TVM (default: ${DEFAULT_TVM_URL})."
 }
 
 function in_array() {
@@ -24,6 +27,8 @@ function in_array() {
 CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
 CUDA="none"
 HASH_TAG=""
+DEFAULT_TVM_URL="https://github.com/apache/tvm"
+TVM_URL="${DEFAULT_TVM_URL}"
 
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -41,6 +46,10 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             usage
             exit -1
+            ;;
+        --tvm-url)
+            TVM_URL=("$2")
+            shift 2
             ;;
         *) # unknown option
             echo "Unknown argument: $arg"
@@ -66,7 +75,9 @@ fi
 
 # check out the tvm
 cd /workspace
-git clone https://github.com/apache/tvm tvm --recursive
+echo "Cloning TVM from ${TVM_URL}"
+git clone "${TVM_URL}" tvm --recursive
+
 if [[ ${HASH_TAG} ]]; then
     cd /workspace/tvm && git checkout ${HASH_TAG} && git submodule update --recursive
 fi


### PR DESCRIPTION
Add a `--tvm-url` option to build wheels from a specific fork or repo. 
 * Add `--tvm-url` option to `build_pip_wheel.sh` and `build_tvm.sh`;
 * Allow pip packages to be created from a specific TVM git repo;
 * Add some information to inform users that more options are available (directing them to `--help` option);
 * Minor cosmetics on `--help` options.

cc @tqchen @icemelon9 