### PR TITLE
Enable Arm Ethos-N NPU support on packages generated using tlcpack

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -19,6 +19,10 @@ RUN bash /install/centos_build_llvm.sh 10.0
 COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
 RUN bash /install/centos_install_patchelf.sh
 
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu100
+++ b/docker/Dockerfile.package-cu100
@@ -19,6 +19,10 @@ RUN bash /install/centos_build_llvm.sh 10.0
 COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
 RUN bash /install/centos_install_patchelf.sh
 
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu101
+++ b/docker/Dockerfile.package-cu101
@@ -19,6 +19,10 @@ RUN bash /install/centos_build_llvm.sh 10.0
 COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
 RUN bash /install/centos_install_patchelf.sh
 
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu102
+++ b/docker/Dockerfile.package-cu102
@@ -19,6 +19,10 @@ RUN bash /install/centos_build_llvm.sh 10.0
 COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
 RUN bash /install/centos_install_patchelf.sh
 
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+source /multibuild/manylinux_utils.sh
+python3_bin="$(cpython_path 3.6)/bin/python"
+
+repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
+repo_dir="ethosn-driver"
+repo_revision="20.08"
+install_path="/opt/arm/$repo_dir"
+
+tmpdir=$(mktemp -d)
+
+# install dependencies for building Arm(r) Ethos(tm)-N series Driver Stack
+yum install -y sparse bc devtoolset-8-gcc-c++ wget
+
+toolchain_bin_path=$(which g++)
+toolchain_path=$(dirname "$toolchain_bin_path")
+
+install_scons()
+{
+  ${python3_bin} -mvenv v
+  . v/bin/activate
+  pip install wheel scons
+}
+
+cleanup()
+{
+  rm -rf "$tmpdir"
+}
+
+trap cleanup 0
+
+cd "$tmpdir"
+
+git clone "$repo_url" "$repo_dir"
+
+install_scons
+
+cd "$repo_dir"
+git checkout "$repo_revision"
+
+cd "driver"
+
+# setting PATH is needed here, due to a bug with scons in CentOS/RHEL
+# see: https://github.com/godotengine/godot/issues/34533
+scons install_prefix="$install_path" install PATH="$toolchain_path"

--- a/scripts/build_tvm.sh
+++ b/scripts/build_tvm.sh
@@ -77,6 +77,7 @@ echo set\(USE_LLVM \"llvm-config --ignore-libllvm\"\) >> config.cmake
 echo set\(USE_RPC ON\) >> config.cmake
 echo set\(USE_SORT ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
+echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
Enable Arm Ethos-N NPU support on packages generated using tlcpack

* Add a script to compile the Arm Ethos-N NPU driver stack, to be added on the produced wheel packages
* Add USE_ETHOSN directive on the TVM builder script