### PR TITLE
Add support to Compute Library for Arm Architecture (ACL)

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -23,6 +23,10 @@ RUN bash /install/centos_install_patchelf.sh
 COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
 RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu100
+++ b/docker/Dockerfile.package-cu100
@@ -23,6 +23,10 @@ RUN bash /install/centos_install_patchelf.sh
 COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
 RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu101
+++ b/docker/Dockerfile.package-cu101
@@ -23,6 +23,10 @@ RUN bash /install/centos_install_patchelf.sh
 COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
 RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/Dockerfile.package-cu102
+++ b/docker/Dockerfile.package-cu102
@@ -23,6 +23,10 @@ RUN bash /install/centos_install_patchelf.sh
 COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
 RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.6

--- a/docker/install/centos_install_arm_compute_library.sh
+++ b/docker/install/centos_install_arm_compute_library.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+set -x
+
+compute_lib_version="v21.02"
+compute_lib_base_url="https://github.com/ARM-software/ComputeLibrary/releases/download/${compute_lib_version}"
+compute_lib_file_name="arm_compute-${compute_lib_version}-bin-linux.tar.gz"
+compute_lib_download_url="${compute_lib_base_url}/${compute_lib_file_name}"
+
+target_lib="linux-arm64-v8a-neon"
+
+extract_dir="arm_compute-${compute_lib_version}-bin-linux"
+install_path="/opt/arm/acl"
+
+tmpdir=$(mktemp -d)
+
+cleanup()
+{
+  rm -rf "$tmpdir"
+}
+
+trap cleanup 0
+
+cd "$tmpdir"
+
+curl -sL "${compute_lib_download_url}" -o "${compute_lib_file_name}"
+tar xzf "${compute_lib_file_name}" 
+
+mkdir -p "${install_path}"
+cp -r "${extract_dir}/include" "${install_path}/"
+cp -r "${extract_dir}/arm_compute" "${install_path}/include/"
+cp -r "${extract_dir}/support" "${install_path}/include/"
+cp -r "${extract_dir}/utils" "${install_path}/include/"
+cp -r "${extract_dir}/lib/${target_lib}" "${install_path}/lib"

--- a/scripts/build_tvm.sh
+++ b/scripts/build_tvm.sh
@@ -89,6 +89,7 @@ echo set\(USE_RPC ON\) >> config.cmake
 echo set\(USE_SORT ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
 echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
+echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
Add support to Compute Library for Arm Architecture (ACL)
 * Add package support to install ACL 21.02
 * Include option to build TVM on Linux using ACL