### PR TITLE
Fix for Arm Ethos-N NPU driver v21.02 script.

### DIFF
--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -13,7 +13,9 @@ install_path="/opt/arm/$repo_dir"
 tmpdir=$(mktemp -d)
 
 # install dependencies for building Arm(r) Ethos(tm)-N series Driver Stack
-yum install -y sparse bc devtoolset-8-gcc-c++ wget
+yum install -y sparse bc devtoolset-7-gcc-c++ wget
+
+source /opt/rh/devtoolset-7/enable
 
 toolchain_bin_path=$(which g++)
 toolchain_path=$(dirname "$toolchain_bin_path")


### PR DESCRIPTION
Fix for Arm Ethos-N NPU driver v21.02 script
* Enables build using the recommended gcc 7 toolchain
* It prepares the script also to be used on both manylinux2010 and manylinux2014
* It helps unblock work being done towards #33 

cc @hogepodge @tqchen  for reviews