### PR TITLE
Update Docker CPU image to manylinux2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Checkout [.github/workflows](.github/workflows)
 1. Build docker images
 
 ```bash
-./docker/build_docker <CONTAINER_TYPE>
+./docker/build_image.sh <CONTAINER_TYPE>
 
 CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cu100|cu101|cu102)
 ```

--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -1,6 +1,6 @@
 # Docker image: tlcpack/package-cpu
 
-FROM quay.io/pypa/manylinux2010_x86_64:2020-12-15-ba3529a
+FROM quay.io/pypa/manylinux2014_x86_64
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh

--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -1,6 +1,6 @@
 # Docker image: tlcpack/package-cpu
 
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64:2021-04-27-6967be9
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh

--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -13,7 +13,9 @@ install_path="/opt/arm/$repo_dir"
 tmpdir=$(mktemp -d)
 
 # install dependencies for building Arm(r) Ethos(tm)-N series Driver Stack
-yum install -y sparse bc devtoolset-8-gcc-c++ wget
+yum install -y sparse bc devtoolset-7-gcc-c++ wget
+
+ source /opt/rh/devtoolset-7/enable
 
 toolchain_bin_path=$(which g++)
 toolchain_path=$(dirname "$toolchain_bin_path")

--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -15,7 +15,7 @@ tmpdir=$(mktemp -d)
 # install dependencies for building Arm(r) Ethos(tm)-N series Driver Stack
 yum install -y sparse bc devtoolset-7-gcc-c++ wget
 
- source /opt/rh/devtoolset-7/enable
+source /opt/rh/devtoolset-7/enable
 
 toolchain_bin_path=$(which g++)
 toolchain_path=$(dirname "$toolchain_bin_path")

--- a/docker/install/centos_install_cmake.sh
+++ b/docker/install/centos_install_cmake.sh
@@ -5,6 +5,5 @@ set -u
 set -o pipefail
 
 /opt/python/cp37-cp37m/bin/pip install cmake ninja
-ln -s /opt/python/cp37-cp37m/bin/cmake /usr/local/bin/cmake
 ln -s /opt/python/cp37-cp37m/bin/ninja /usr/local/bin/ninja
 strip /opt/_internal/cpython-3.*/lib/python3.7/site-packages/cmake/data/bin/*

--- a/docker/install/centos_install_core.sh
+++ b/docker/install/centos_install_core.sh
@@ -5,11 +5,11 @@ set -u
 set -o pipefail
 
 # install libraries for building c++ core on ubuntu
-yum install -y wget xz python-pip
+yum install -y wget xz python-pip python3-pip python34-pip
 
 # install multibuild utils
 git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && \
     git checkout 9e2349833e994cb829b77cc08f1aacc6ab6d2458
 
 # install argparse
-pip install argparse
+pip3 install argparse


### PR DESCRIPTION
Updates the manylinux base image to 2014 to address the incompatibility
of cmake in the 2010 image for building LLVM.

Co-authored-by: Leandro Nunes <Leandro.Nunes@arm.com>