### PR TITLE
[WORKFLOW] Manylinux wheel.

### DIFF
--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -1,0 +1,46 @@
+# GH actions.
+name: Wheel-Manylinux-Nightly
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * *' # 6 AM UTC
+
+jobs:
+  Build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        pkg: ['tlcpack-nightly']
+        # matrix of build configs
+        config:
+          - cuda: none
+            image: tlcpack/package-cpu:v0.2
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: TVM checkout
+      run: |
+        git clone https://github.com/apache/tvm tvm --recursive
+    - name: Sync Package
+      run: python common/sync_package.py ${{ matrix.pkg }}
+    - name: Build
+      env:
+        IMAGE: ${{ matrix.config.image }}
+        CUDA: ${{ matrix.config.cuda }}
+      run: |
+        docker/bash.sh $IMAGE ./wheel/build_wheel_manylinux.sh --cuda $CUDA
+    - name: Wheel-Deploy
+      if: github.ref == 'refs/heads/main'
+      env:
+        GITHUB_TOKEN: ${{ secrets.TLCPACK_GITHUB_TOKEN }}
+      run: |
+        python -m pip install github3.py
+        python wheel/wheel_upload.py --tag v0.7.dev1 tvm/python/repaired_wheels

--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -1,5 +1,5 @@
 # GH actions.
-name: Wheel-CPU-Nightly
+name: Wheel-WinMac-Nightly
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -24,23 +24,35 @@ Checkout [.github/workflows](.github/workflows)
 CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cu100|cu101|cu102)
 ```
 
-2. Build tlcpack PIP wheels.
+2. Checkout tvm and sync version
 
-To build wheels for all Python versions (3.6, 3.7, 3.8) with CPU and all CUDA versions (10.0, 10.1, 10.2), run
+```
+git clone https://github.com/apache/tvm --recursive
+# synchronize the package version
+python common/sync_package.py [tlcpack|tlcpack-nightly]
+```
 
-```bash
-./scripts/build_pip_wheel.sh
+The nightly will point to the latest main, tlcpack
+will point to a stable build hashtag defined in common/sync_package.py
+
+
+3. Build tlcpack manylinux wheels.
+
+```
+./docker/bash.sh [docker-image] ./wheel/build_manylinux_wheel.sh --cuda none
 ```
 
 To build wheels for a specific CUDA version, for example, CUDA 10.1, run
 
 ```bash
-./scripts/build_pip_wheel.sh --cuda 10.1
+./docker/bash.sh [docker-image] ./wheel/build_manylinux_wheel.sh --cuda 10.1
 ```
 
-Or, to build wheels for CPU only, run
-```bash
-./scripts/build_pip_wheel.sh --cuda none
-```
+The docker image is built in step 1 and needs to match the cuda version.
 
-Check `./scripts/build_pip_wheel.sh --help` for other options.
+4. Get the wheels
+
+The wheels are now available in
+```
+./tvm/python/repaird_wheels
+```

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -17,7 +17,7 @@ def py_str(cstr):
     return cstr.decode("utf-8")
 
 
-def checkout_stable(src):
+def checkout_source(src, tag):
     def run_cmd(cmd):
         proc = subprocess.Popen(
             cmd, cwd=src, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
@@ -28,9 +28,9 @@ def checkout_stable(src):
             msg += py_str(out)
             raise RuntimeError(msg)
 
-    run_cmd(["git", "checkout", __stable_build__])
+    run_cmd(["git", "checkout", "-f", tag])
     run_cmd(["git", "submodule", "update"])
-    print("git checkout %s" % __stable_build__)
+    print("git checkout %s" % tag)
 
 
 def update(file_name, rewrites, dry_run=False):
@@ -98,7 +98,10 @@ def main():
     args = parser.parse_args()
 
     if 'nightly' not in args.name:
-        checkout_stable(args.src)
+        checkout_source(args.src, __stable_build__)
+    else:
+        checkout_source(args.src, "origin/main")
+
     update_setup(args)
     update_conda(args)
 

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+source /multibuild/manylinux_utils.sh
+
+function usage() {
+    echo "Usage: $0 [--cuda CUDA]"
+    echo
+    echo -e "--cuda {none 10.0 10.1 10.2}"
+    echo -e "\tSpecify the CUDA version in the TVM (default: none)."
+}
+
+function in_array() {
+    KEY=$1
+    ARRAY=$2
+    for e in ${ARRAY[*]}; do
+        if [[ "$e" == "$1" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
+CUDA="none"
+HASH_TAG=""
+DEFAULT_TVM_URL="https://github.com/apache/tvm"
+TVM_URL="${DEFAULT_TVM_URL}"
+
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case $arg in
+        --cuda)
+            CUDA=$2
+            shift
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit -1
+            ;;
+        *) # unknown option
+            echo "Unknown argument: $arg"
+            echo
+            usage
+            exit -1
+            ;;
+    esac
+done
+
+if ! in_array "${CUDA}" "${CUDA_OPTIONS[*]}" ; then
+    echo "Invalid CUDA option: ${CUDA}"
+    echo
+    echo 'CUDA can only be {"none", "10.0", "10.1", "10.2"}'
+    exit -1
+fi
+
+if [[ ${CUDA} == "none" ]]; then
+    echo "Building TVM for CPU only"
+else
+    echo "Building TVM with CUDA ${CUDA}"
+fi
+
+# config the cmake
+cd /workspace/tvm
+echo set\(USE_LLVM \"llvm-config --ignore-libllvm --link-static\"\) >> config.cmake
+echo set\(USE_RPC ON\) >> config.cmake
+echo set\(USE_SORT ON\) >> config.cmake
+echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
+echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
+echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
+if [[ ${CUDA} != "none" ]]; then
+    echo set\(USE_CUDA ON\) >> config.cmake
+    echo set\(USE_CUBLAS ON\) >> config.cmake
+    echo set\(USE_CUDNN ON\) >> config.cmake
+fi
+
+# compile the tvm
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc)
+
+UNICODE_WIDTH=32  # Dummy value, irrelevant for Python 3
+CPYTHON36_PATH="$(cpython_path 3.6 ${UNICODE_WIDTH})"
+CPYTHON37_PATH="$(cpython_path 3.7 ${UNICODE_WIDTH})"
+CPYTHON38_PATH="$(cpython_path 3.8 ${UNICODE_WIDTH})"
+PYTHON36="${CPYTHON36_PATH}/bin/python"
+PYTHON37="${CPYTHON37_PATH}/bin/python"
+PYTHON38="${CPYTHON38_PATH}/bin/python"
+PIP36="${CPYTHON36_PATH}/bin/pip"
+PIP37="${CPYTHON37_PATH}/bin/pip"
+PIP38="${CPYTHON38_PATH}/bin/pip"
+
+# build the python wheel
+cd /workspace/tvm/python
+PATH="${CPYTHON36_PATH}/bin:$PATH" ${PYTHON36} setup.py bdist_wheel
+PATH="${CPYTHON37_PATH}/bin:$PATH" ${PYTHON37} setup.py bdist_wheel
+PATH="${CPYTHON38_PATH}/bin:$PATH" ${PYTHON38} setup.py bdist_wheel
+
+# repair python wheels
+mkdir -p repared_wheels
+auditwheel repair --plat ${AUDITWHEEL_PLAT} dist/tlcpack*cp36*.whl -w repaired_wheels/
+auditwheel repair --plat ${AUDITWHEEL_PLAT} dist/tlcpack*cp37*.whl -w repaired_wheels/
+auditwheel repair --plat ${AUDITWHEEL_PLAT} dist/tlcpack*cp38*.whl -w repaired_wheels/
+
+# skip tests since cuda might require the cuda runtime to be avaialble.


### PR DESCRIPTION
- Add build script in wheel folder that is based on the original one in script folder (scripts/build_pip_wheel.sh=>wheel/build_wheel_manylinux.sh)
  - Remove the tvm cloning part and left that to the workflow
  - Remove the quick testing part
- Use the same name patching and syncing mechanism via common/sync_package.py
- Add github actions to build the manylinux matrix, more matrix value of cuda config and image name can be added.

Co-authored-by: Chris Hoge <chris@hogepodge.com>