### PR TITLE
Enable USE_MICRO on tlcpack build.

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -65,6 +65,7 @@ echo set\(USE_SORT ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
 echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
+echo set\(USE_MICRO ON\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
Currently we don't have utvm enabled by default in a regular TVM build. This PR adds USE_MICRO ON so that the package contains utvm.

Motivated by https://github.com/apache/tvm/pull/8086, which makes utvm mandatory as a dependency for tvmc.

cc @gromero @areusch @tqchen for reviews