### PR TITLE
Changed ACL version from 21.02 to 21.05

### DIFF
--- a/docker/install/centos_install_arm_compute_library.sh
+++ b/docker/install/centos_install_arm_compute_library.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-compute_lib_version="v21.02"
+compute_lib_version="v21.05"
 compute_lib_base_url="https://github.com/ARM-software/ComputeLibrary/releases/download/${compute_lib_version}"
 compute_lib_file_name="arm_compute-${compute_lib_version}-bin-linux.tar.gz"
 compute_lib_download_url="${compute_lib_base_url}/${compute_lib_file_name}"
@@ -25,7 +25,7 @@ trap cleanup 0
 cd "$tmpdir"
 
 curl -sL "${compute_lib_download_url}" -o "${compute_lib_file_name}"
-tar xzf "${compute_lib_file_name}" 
+tar xzf "${compute_lib_file_name}"
 
 mkdir -p "${install_path}"
 cp -r "${extract_dir}/include" "${install_path}/"


### PR DESCRIPTION
This PR changes ACL version from 21.02 to 21.05

*ACL stands for "Compute Library for the Arm® Architecture"