### PR TITLE
Update https://tlcpack.ai/wheels only with checked valid URLs

### DIFF
--- a/.github/workflows/prune_nightly.yaml
+++ b/.github/workflows/prune_nightly.yaml
@@ -53,7 +53,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.TLCPACK_GITHUB_TOKEN }}
       run: >-
-        python -m pip install github3.py &&
+        python -m pip install -y github3.py requests &&
         python wheel/wheel_prune_and_sync.py
     - name: Conda-Prune
       if: github.ref == 'refs/heads/main'

--- a/wheel/wheel_prune_and_sync.py
+++ b/wheel/wheel_prune_and_sync.py
@@ -6,6 +6,8 @@ import argparse
 import subprocess
 from datetime import datetime
 
+import requests
+
 
 def py_str(cstr):
     return cstr.decode("utf-8")
@@ -65,6 +67,16 @@ def group_wheels(wheels):
     return group_map
 
 
+def url_is_valid(url):
+    """Check if a given URL is valid, i.e. it returns 200 OK when requested."""
+    r = requests.get(url)
+
+    if r.status_code != 200:
+        print("Warning: HTTP code %s for url %s" % (r.status_code, url))
+
+    return r.status_code == 200
+
+
 def run_prune(args, group_map):
     keep_list = []
     remove_list = []
@@ -90,7 +102,7 @@ def list_wheels(repo):
     for release in repo.releases():
         tag = release.tag_name
         for asset in release.assets():
-            if asset.name.endswith(".whl"):
+            if asset.name.endswith(".whl") and url_is_valid(asset.browser_download_url):
                 wheels.append(asset)
     return wheels
 


### PR DESCRIPTION
Update https://tlcpack.ai/wheels only with checked valid URLs:
 * This is to tackle a problem in which a corrupted file is uploaded to GitHub, and the https://tlcpack.ai/wheels blindly updates the list of wheels based on file names
 * It adds further checking to validate the URLs being considered for updates
 * Fixes #54

cc @tqchen for reviews