### PR TITLE
Automatically trigger Docker image validation job, when new tags are uploaded

### DIFF
--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -300,6 +300,15 @@ pipeline {
   } // stages
   post {
     success {
+
+      // When the build is successful, trigger a validation build, using the tag just produced.
+      build job: 'daily-docker-image-validate',
+        wait: false,
+        propagate: false,
+        parameters: [
+          [$class: 'StringParameterValue', name: 'tlcpack_staging_tag', value: "${TVM_DOCKER_TAG}"]
+        ]
+
       discordSend description: "New images published on DockerHub with tag `${TVM_DOCKER_TAG}`. Use `docker pull tlcpackstaging/<image_type>:${TVM_DOCKER_TAG}` to download the images. Image types: `ci_arm`, `ci_cpu`, `ci_gpu`, `ci_i386`, `ci_lint`, `ci_qemu`, `ci_wasm`.",
         link: "https://hub.docker.com/u/tlcpackstaging/",
         result: currentBuild.currentResult,


### PR DESCRIPTION
Automatically trigger Docker image validation job, when new tags are uploaded:

* This changes the Jenkins job `daily-docker-image-rebuild` so that it triggers a `daily-docker-image-validate` job once
  new tags are successfully created and images are uploaded in `tlcpackstaging` docker hub.

For reference, all jobs mentioned here are hosted at https://ci.tlcpack.ai/job/docker-images-ci/

cc @tqchen @areusch @jroesch @tmoreau89 @mbrookhart @Mousius