### PR TITLE
Add CUDA 11.1 build support

### DIFF
--- a/.github/workflows/conda_gpu_nigthly.yaml
+++ b/.github/workflows/conda_gpu_nigthly.yaml
@@ -22,6 +22,8 @@ jobs:
             image: 'tlcpack/package-cu101:v0.3'
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:v0.3'
+          - cuda: '11.1'
+            image: 'tlcpack/package-cu111:v0.3'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/prune_nightly.yaml
+++ b/.github/workflows/prune_nightly.yaml
@@ -64,4 +64,6 @@ jobs:
         python conda/anaconda_prune.py tlcpack/tlcpack-nightly &&
         python conda/anaconda_prune.py tlcpack/tlcpack-nightly-libs &&
         python conda/anaconda_prune.py tlcpack/tlcpack-nightly-cu100 &&
-        python conda/anaconda_prune.py tlcpack/tlcpack-nightly-cu100-libs
+        python conda/anaconda_prune.py tlcpack/tlcpack-nightly-cu100-libs &&
+        python conda/anaconda_prune.py tlcpack/tlcpack-nightly-cu111 &&
+        python conda/anaconda_prune.py tlcpack/tlcpack-nightly-cu111-libs

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -26,6 +26,8 @@ jobs:
             image: 'tlcpack/package-cu101:v0.3'
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:v0.3'
+          - cuda: '11.1'
+            image: 'tlcpack/package-cu111:v0.3'
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Checkout [.github/workflows](.github/workflows)
 ```bash
 ./docker/build_image.sh <CONTAINER_TYPE>
 
-CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cu100|cu101|cu102)
+CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cu100|cu101|cu102|cu111)
 ```
 
 2. Checkout tvm and sync version

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -147,7 +147,7 @@ def main():
     parser.add_argument("--cuda",
                         type=str,
                         default="none",
-                        choices=["none", "10.0", "10.1", "10.2"],
+                        choices=["none", "10.0", "10.1", "10.2", "11.1"],
                         help="CUDA version to be linked to the resultant binaries,"
                              "or none, to disable CUDA. Defaults to none.")
     parser.add_argument("--package-name",

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -4,6 +4,7 @@
 {% set version = '0.7.0' %}
 
 {% set cuda_tag = cuda_version | replace('.', '') %} # [cuda]
+{% set cudnn_v = '8.1.0' if cuda_version.startswith('11') else '7.6.0' %} # [cuda]
 {% set pkg_name = pkg_name + '-cu' + cuda_tag %} # [cuda]
 {% set build_tag = environ.get('GIT_BUILD_STR', 'unknown') %}
 {% set build_tag = build_tag + '_h' + PKG_HASH + '_' + PKG_BUILDNUM %}
@@ -47,10 +48,10 @@ outputs:
         - zlib
         - llvmdev ==10.0.0
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - {{ pin_compatible('cudnn', lower_bound=cudnn_v, max_pin='x') }}  # [cuda]
       run:
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - {{ pin_compatible('cudnn', lower_bound=cudnn_v, max_pin='x') }}  # [cuda]
 
   - name: {{ pkg_name }}
     script: install_python_pkg.sh  # [not win]

--- a/docker/Dockerfile.package-cu111
+++ b/docker/Dockerfile.package-cu111
@@ -1,0 +1,53 @@
+# Docker image: tlcpack/package-cu111
+
+FROM pytorch/manylinux-cuda111
+
+# install core
+COPY install/centos_install_core.sh /install/centos_install_core.sh
+RUN bash /install/centos_install_core.sh
+
+# install cmake
+COPY install/centos_install_cmake.sh /install/centos_install_cmake.sh
+RUN bash /install/centos_install_cmake.sh
+
+# build llvm
+COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
+RUN bash /install/centos_build_llvm.sh 10.0
+
+# upgrade patchelf due to the bug in patchelf 0.10
+# see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected
+COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
+RUN bash /install/centos_install_patchelf.sh
+
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
+# install python packages
+COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
+RUN bash /install/centos_install_python_package.sh 3.6
+RUN bash /install/centos_install_python_package.sh 3.7
+RUN bash /install/centos_install_python_package.sh 3.8
+
+COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
+RUN bash /install/centos_install_auditwheel.sh
+
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+
+
+# Environment variables
+ENV PATH=/usr/local/cuda/bin:/opt/conda/bin:${PATH}
+ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}
+ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
+ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LD_LIBRARY_PATH}
+ENV AUDITWHEEL_PLAT=manylinux2014_x86_64
+
+# The upstream PyTorch image comes with both 10.2 and 11.1, with the default symlinked to 10.2
+# To simplify the build process, symlink the default to 11.1 explicitly
+RUN rm -rf /usr/local/cuda && ln -sf /usr/local/cuda-11.1 /usr/local/cuda

--- a/docker/Dockerfile.package-cu111
+++ b/docker/Dockerfile.package-cu111
@@ -51,3 +51,5 @@ ENV AUDITWHEEL_PLAT=manylinux2014_x86_64
 # The upstream PyTorch image comes with both 10.2 and 11.1, with the default symlinked to 10.2
 # To simplify the build process, symlink the default to 11.1 explicitly
 RUN rm -rf /usr/local/cuda && ln -sf /usr/local/cuda-11.1 /usr/local/cuda
+ENV CUDA_VERSION=11.1
+

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -6,7 +6,7 @@
 # Usage: build_image.sh <CONTAINER_TYPE>
 #
 # CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,
-#                 (cpu|cu100|cu101|cu102)
+#                 (cpu|cu100|cu101|cu102|cu111)
 #
 # The built image will show as tlpack/package-[type]:staging
 #
@@ -15,7 +15,7 @@ if [[ $# -lt 1 ]]; then
     echo "$0 <CONTAINER_TYPE>"
     echo
     echo "CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,"
-    echo "                (cpu|cu100|cu101|cu102)"
+    echo "                (cpu|cu100|cu101|cu102|cu111)"
     exit -1
 fi
 

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -2,10 +2,11 @@
 
 source /multibuild/manylinux_utils.sh
 
+
 function usage() {
     echo "Usage: $0 [--cuda CUDA]"
     echo
-    echo -e "--cuda {none 10.0 10.1 10.2}"
+    echo -e "--cuda {none 10.0 10.1 10.2 11.1}"
     echo -e "\tSpecify the CUDA version in the TVM (default: none)."
 }
 
@@ -20,7 +21,7 @@ function in_array() {
     return 1
 }
 
-CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
+CUDA_OPTIONS=("none" "10.0" "10.1" "10.2" "11.1")
 CUDA="none"
 
 while [[ $# -gt 0 ]]; do
@@ -47,7 +48,7 @@ done
 if ! in_array "${CUDA}" "${CUDA_OPTIONS[*]}" ; then
     echo "Invalid CUDA option: ${CUDA}"
     echo
-    echo 'CUDA can only be {"none", "10.0", "10.1", "10.2"}'
+    echo 'CUDA can only be {"none", "10.0", "10.1", "10.2", "11.1"}'
     exit -1
 fi
 
@@ -103,7 +104,7 @@ fi
 # repair python wheels
 # skip libcuda
 mkdir -p repared_wheels
-auditwheel repair ${AUDITWHEEL_OPTS} dist/tlcpack*cp36*.whl
-auditwheel repair ${AUDITWHEEL_OPTS} dist/tlcpack*cp37*.whl
-auditwheel repair ${AUDITWHEEL_OPTS} dist/tlcpack*cp38*.whl
+auditwheel repair ${AUDITWHEEL_OPTS} dist/tlc*cp36*.whl
+auditwheel repair ${AUDITWHEEL_OPTS} dist/tlc*cp37*.whl
+auditwheel repair ${AUDITWHEEL_OPTS} dist/tlc*cp38*.whl
 # skip tests since cuda might require the cuda runtime to be avaialble.


### PR DESCRIPTION
I have added a Dockerfile + relevant options to enable building using a CUDA 11.1 image. I have also updated the Github workflows.

It turns out that the upstream CUDA 11.1 image contains both a 10.2 and 11.1 installation, which caused issues as the default CUDA install was symlinked to 10.2. Once this is fixed, compilation went smoothly.

I don't believe that the Github action will run just yet: I think a maintainer needs to build the image and tag it appropriately?

Finally - I have not been able to build the conda package successfully (but I cannot do this for the existing packages either). The shared libraries do not appear to get bundled into the wheel, causing a dynamic linking issue when you try to import tvm in Python