### PR TITLE
Set USE_MICRO_STANDALONE_RUNTIME ON in the Linux wheel builds

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -66,6 +66,7 @@ echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
 echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
+echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
This is needed so that we can build packages that will include `standalone_crt` directory as `data_files`.
I'll send a counterpart PR on TVM to enable the inclusion of the crt.

cc @areusch @tqchen @Mousius for reviews.