### PR TITLE
Do not prematurely interpolate secret variables in Jenkinsfile

### DIFF
--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -35,9 +35,10 @@ def upload_to_docker_hub(image_type) {
   // 'docker/build.sh' makes some assumptions on the images produced.
   // The expected name is composed by ${BUILD_TAG}.${image_type}:${TVM_DOCKER_TAG}
 
-  sh """
+  sh '''
     docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_KEY}
-
+  '''
+  sh """
     docker tag \
       ${BUILD_TAG}.${image_type}:${TVM_DOCKER_TAG} \
       ${DOCKERHUB_USER}/${image_type}:${TVM_DOCKER_TAG}
@@ -314,14 +315,14 @@ pipeline {
         link: "https://hub.docker.com/u/tlcpackstaging/",
         result: currentBuild.currentResult,
         title: "${JOB_NAME}",
-        webhookURL: "${DISCORD_WEBHOOK}"
+        webhookURL: '${DISCORD_WEBHOOK}'
     }
     unsuccessful {
       discordSend description: "Failed to generate Docker images using TVM hash `${TVM_CURRENT_SHORT_REF}`. See logs at ${BUILD_URL}.",
         link: "${BUILD_URL}",
         result: currentBuild.currentResult,
         title: "${JOB_NAME}",
-        webhookURL: "${DISCORD_WEBHOOK}"
+        webhookURL: '${DISCORD_WEBHOOK}'
     }
     always {
       cleanWs();

--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -95,7 +95,7 @@ pipeline {
   parameters {
     string(name:"TVM_GIT_REV",
            defaultValue: "main",
-           description: 'Git revision to checkout.'),
+           description: 'Git revision to checkout.')
     string(name:"DOCKERHUB_USER", defaultValue: "tlcpackstaging",
            description: 'User that pushes images to Dockerhub.')
   }

--- a/jenkins/JenkinsFile-validate-docker-images
+++ b/jenkins/JenkinsFile-validate-docker-images
@@ -39,7 +39,7 @@ def retag_and_upload_to_docker_hub(image_type) {
   // happen very fast, as all the layers already exist in the 
   // remote Docker registry.
 
-  sh """
+  sh '''
     docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_KEY}
 
     docker pull ${DOCKERHUB_USER}/${image_type}:${DOCKER_TAG}
@@ -49,7 +49,7 @@ def retag_and_upload_to_docker_hub(image_type) {
       ${DOCKERHUB_USER}/${image_type}:${DOCKER_VALIDATED_TAG}
 
     docker push ${DOCKERHUB_USER}/${image_type}:${DOCKER_VALIDATED_TAG}
-  """
+ '''
 
 }
 
@@ -201,14 +201,14 @@ pipeline {
         link: "https://hub.docker.com/u/tlcpackstaging/",
         result: currentBuild.currentResult,
         title: "${JOB_NAME}",
-        webhookURL: "${DISCORD_WEBHOOK}"
+        webhookURL: '${DISCORD_WEBHOOK}'
     }
     unsuccessful {
       discordSend description: "Failed to validate Docker images with tag `${DOCKER_TAG}`. See logs at ${BUILD_URL}.",
         link: "${BUILD_URL}",
         result: currentBuild.currentResult,
         title: "${JOB_NAME}",
-        webhookURL: "${DISCORD_WEBHOOK}"
+        webhookURL: '${DISCORD_WEBHOOK}'
     }
     always {
       cleanWs();


### PR DESCRIPTION
As mentioned [here](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation), secret variables ought to be interpolated only once a helper script is invoked, and not prematurely within the Jenkinsfile. I've replaced double quotes with single quotes where applicable.