### PR TITLE
Enable Arm(R) Ethos(TM)-U NPU as part of tlcpack.

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -67,6 +67,7 @@ echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
+echo set\(USE_ETHOSU ON\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
Given we recently added support for Arm(R) Ethos(TM)-U NPU in TVM, this change enables "USE_ETHOSU" as part of the tlcpack build.

Related to https://github.com/apache/tvm/pull/8854.

cc @tqchen @areusch @icemelon @jroesch for reviews and merge when possible.