### PR TITLE
Fix GitHub API usage to get minor LLVM version from releases API.

### DIFF
--- a/docker/install/centos_build_llvm.sh
+++ b/docker/install/centos_build_llvm.sh
@@ -7,7 +7,7 @@ LLVM_VERSION_MAJOR=$1
 source /multibuild/manylinux_utils.sh
 
 detect_llvm_version() {
-  curl -sL https://api.github.com/repos/llvm/llvm-project/releases | \
+  curl -sL "https://api.github.com/repos/llvm/llvm-project/releases?per_page=50" | \
     grep tag_name | \
     grep -o "llvmorg-${LLVM_VERSION_MAJOR}[^\"]*" | \
     grep -v rc | \


### PR DESCRIPTION
Fix GitHub API usage to get minor LLVM version from releases API.
* By default, the API returns the first 30 results. As the version we use gets older, we now need to get more results for 10.x to appear in the results. This breaks the way we resolve LLVM versions to be built
* This change increase the number of results from 30 to 50

Reference for the parameters being used: https://docs.github.com/en/rest/reference/repos#releases

cc @icemelon @tqchen @areusch @Mousius for reviews