### PR TITLE
Fix wrong script name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ will point to a stable build hashtag defined in common/sync_package.py
 3. Build tlcpack manylinux wheels.
 
 ```bash
-./docker/bash.sh [docker-image] ./wheel/build_manylinux_wheel.sh --cuda none
+./docker/bash.sh [docker-image] ./wheel/build_wheel_manylinux.sh --cuda none
 ```
 
 To build wheels for a specific CUDA version, for example, CUDA 10.1, run
 
 ```bash
-./docker/bash.sh [docker-image] ./wheel/build_manylinux_wheel.sh --cuda 10.1
+./docker/bash.sh [docker-image] ./wheel/build_wheel_manylinux.sh --cuda 10.1
 ```
 
 The docker image is built in step 1 and needs to match the cuda version.


### PR DESCRIPTION
There is a wrong script name `build_manylinux_wheel.sh` in README.md,  actually this script named  `build_wheel_manylinux.sh`. This PR aims to fix this minor error.