### PR TITLE
Enable CMSIS-NN support in tlcpack builds

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -69,6 +69,7 @@ echo set\(USE_ARM_COMPUTE_LIB /opt/arm/acl\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_ETHOSU ON\) >> config.cmake
+echo set\(USE_CMSISNN ON\) >> config.cmake
 if [[ ${CUDA} != "none" ]]; then
     echo set\(USE_CUDA ON\) >> config.cmake
     echo set\(USE_CUBLAS ON\) >> config.cmake


### PR DESCRIPTION
This enables CMSIS-NN support in tlcpack builds. 