### PR TITLE
Remove Python 3.6 installation from Dockerfile.package-cu102

### DIFF
--- a/docker/Dockerfile.package-cu102
+++ b/docker/Dockerfile.package-cu102
@@ -29,7 +29,6 @@ RUN bash /install/centos_install_arm_compute_library.sh
 
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
-RUN bash /install/centos_install_python_package.sh 3.6
 RUN bash /install/centos_install_python_package.sh 3.7
 RUN bash /install/centos_install_python_package.sh 3.8
 


### PR DESCRIPTION
* Removing it due to deprecation and not being present in the latest version on the base image

Base image information:
```
pytorch/manylinux-cuda102           latest                      2146d9ccbb6e
```


cc @areusch @tqchen @Mousius 