### PR TITLE
Update centos_install_arm_ethosn_driver_stack.sh to use Python 3.7

### DIFF
--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -3,7 +3,7 @@
 set -e
 
 source /multibuild/manylinux_utils.sh
-python3_bin="$(cpython_path 3.6)/bin/python"
+python3_bin="$(cpython_path 3.7)/bin/python"
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"


### PR DESCRIPTION
As Dockerfile.package-cu102 does not have Python 3.6 (EOL), moving dependency installation script `centos_install_arm_ethosn_driver_stack.sh` to use Python 3.7 instead.

cc @tqchen @areusch @Mousius