### PR TITLE
[CI] Add ci-hexagon image build

### DIFF
--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -305,6 +305,28 @@ pipeline {
           } // post
         } // stage
 
+        stage('ci-hexagon') {
+          agent { node { label 'CPU' } }
+          steps {
+            ws(per_exec_ws("tvm/docker-ci-hexagon")) {
+              cleanWs();
+              init_git()
+              dir('tvm'){
+                sh "${docker_build} ci_hexagon --tag ${TVM_DOCKER_TAG}"
+              }
+
+              upload_to_docker_hub("ci_hexagon");
+
+            }
+          } // steps
+          post {
+            always {
+              cleanup_docker_image("ci_hexagon");
+              cleanWs();
+            }
+          } // post
+        } // stage
+
       } // parallel
     } // stage: Build
   } // stages
@@ -319,7 +341,7 @@ pipeline {
           [$class: 'StringParameterValue', name: 'tlcpack_staging_tag', value: "${TVM_DOCKER_TAG}"]
         ]
 
-      discordSend description: "New images published on DockerHub with tag `${TVM_DOCKER_TAG}`. Use `docker pull tlcpackstaging/<image_type>:${TVM_DOCKER_TAG}` to download the images. Image types: `ci_arm`, `ci_cpu`, `ci_gpu`, `ci_i386`, `ci_lint`, `ci_qemu`, `ci_wasm`.",
+      discordSend description: "New images published on DockerHub with tag `${TVM_DOCKER_TAG}`. Use `docker pull tlcpackstaging/<image_type>:${TVM_DOCKER_TAG}` to download the images. Image types: `ci_arm`, `ci_cpu`, `ci_gpu`, `ci_i386`, `ci_lint`, `ci_qemu`, `ci_wasm`, `ci_hexagon`.",
         link: "https://hub.docker.com/u/tlcpackstaging/",
         result: currentBuild.currentResult,
         title: "${JOB_NAME}",


### PR DESCRIPTION
This is a follow up PR to https://github.com/apache/tvm/pull/10263
After https://github.com/apache/tvm/pull/10263 is merged, we can merge this PR to add ci-hexagon build.