### PR TITLE
Enable tlcpack Python 3.9 wheel package

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -43,7 +43,7 @@ function audit_tlcpack_wheel() {
 }
 
 TVM_PYTHON_DIR="/workspace/tvm/python"
-PYTHON_VERSIONS=("3.6" "3.7" "3.8")
+PYTHON_VERSIONS=("3.6" "3.7" "3.8" "3.9")
 CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
 CUDA="none"
 


### PR DESCRIPTION
Enable Python 3.9 package as discussed in https://github.com/tlc-pack/tlcpack/issues/96.