### PR TITLE
[Do not merge] Enable package uploading to PyPI using a new GitHub Action pipeline

### DIFF
--- a/.github/workflows/wheel_manylinux_pypi_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_pypi_nightly.yaml
@@ -1,0 +1,52 @@
+# GH actions.
+name: Wheel-Manylinux-Pypi
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * *' # 5 AM UTC
+
+jobs:
+  Build:
+    strategy:
+      matrix:
+        pkg: ['pypi-nightly']
+        # matrix of build configs
+        config:
+          - cuda: 'none'
+            image: 'tlcpack/package-cpu:v0.4'
+            package_name: 'apache-tvm'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: TVM checkout
+      run: |
+        git clone https://github.com/apache/tvm tvm --recursive
+    - name: Sync Package
+      run: |
+        python common/sync_package.py \
+          --cuda ${{ matrix.config.cuda }} \
+          --package-name ${{ matrix.config.package_name }} \
+          ${{ matrix.pkg }}
+    - name: Build
+      env:
+        IMAGE: ${{ matrix.config.image }}
+        CUDA: ${{ matrix.config.cuda }}
+      run: |
+        docker/bash.sh --no-gpu $IMAGE ./wheel/build_wheel_manylinux.sh --cuda $CUDA
+    - name: Wheel-Deploy-Pypi
+      env:
+        TWINE_NON_INTERACTIVE: '1'
+        TWINE_REPOSITORY: 'pypi'
+        TWINE_USERNAME: 'tvm'
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        python3 -m pip install twine
+        twine upload tvm/python/repaired_wheels

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -39,7 +39,7 @@ function audit_tlcpack_wheel() {
 
     cd "${TVM_PYTHON_DIR}" && \
       mkdir -p repared_wheel && \
-      auditwheel repair ${AUDITWHEEL_OPTS} dist/tlcpack*cp${python_version_str}*.whl
+      auditwheel repair ${AUDITWHEEL_OPTS} dist/*cp${python_version_str}*.whl
 }
 
 TVM_PYTHON_DIR="/workspace/tvm/python"


### PR DESCRIPTION
Add a new GitHub Action pipeline to run every night, to upload "CPU" (i.e. non-CUDA) packages to PyPI under apache-tvm namespace, using the latest code from 'main'.

cc @areusch @driazati @u99127 @Mousius 