### PR TITLE
Enable package uploading to PyPI using a new GitHub Action pipeline

### DIFF
--- a/.github/workflows/conda_cpu_nigthly.yaml
+++ b/.github/workflows/conda_cpu_nigthly.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         git clone https://github.com/apache/tvm tvm --recursive
     - name: Sync Package
-      run: python common/sync_package.py ${{ matrix.pkg }}
+      run: python3 common/sync_package.py ${{ matrix.pkg }}
     - name: Conda-Build@Win
       if: startsWith(matrix.os, 'windows')
       shell: cmd /C call {0}

--- a/.github/workflows/wheel_manylinux_pypi_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_pypi_nightly.yaml
@@ -1,0 +1,55 @@
+# GH actions.
+name: Wheel-Manylinux-Pypi
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * *' # 5 AM UTC
+
+jobs:
+  Build:
+    strategy:
+      matrix:
+        pkg: ['pypi-nightly']
+        # matrix of build configs
+        config:
+          - cuda: 'none'
+            image: 'tlcpack/package-cpu:v0.4'
+            package_name: 'apache-tvm'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: TVM checkout
+      run: |
+        git clone https://github.com/apache/tvm tvm --recursive
+    - name: Sync Package
+      run: |
+        python3 common/sync_package.py \
+          --cuda ${{ matrix.config.cuda }} \
+          --package-name ${{ matrix.config.package_name }} \
+          --use-public-version \
+          ${{ matrix.pkg }}
+    - name: Build
+      env:
+        IMAGE: ${{ matrix.config.image }}
+        CUDA: ${{ matrix.config.cuda }}
+      run: |
+        docker/bash.sh --no-gpu $IMAGE ./wheel/build_wheel_manylinux.sh --cuda $CUDA
+    - name: Wheel-Deploy-Pypi
+      if: github.ref == 'refs/heads/main'
+      env:
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_REPOSITORY: pypi
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        python3 -m pip install twine
+        twine upload tvm/python/repaired_wheels/*

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -85,18 +85,29 @@ def get_version_tag():
 
 
 def update_libinfo(args):
-    _ , local_ver = get_version_tag()
+    pub_ver, local_ver = get_version_tag()
+
+    # Set the version to be compliant with what is accepted for
+    # PyPI. A valid version string looks like "0.8.dev1473"
+    package_ver = pub_ver if args.use_public_version else local_ver
 
     update(
         os.path.join(args.src, "python", "tvm", "_ffi", "libinfo.py"),
-        [("(?<=__version__ = \")[^\"]+", local_ver)],
+        [("(?<=__version__ = \")[^\"]+", package_ver)],
         args.dry_run
     )
 
 
 def update_setup(args, package_name):
+    pub_ver, local_ver = get_version_tag()
+
+    # Set the version to be compliant with what is accepted for
+    # PyPI. A valid version string looks like "0.8.dev1473"
+    package_ver = pub_ver if args.use_public_version else local_ver
+
     rewrites = [
         (r'(?<=name=")[^\"]+', name_with_cuda(args, package_name)),
+        (r'(?<=version=)[^\,]+', f'"{package_ver}"'),
         (r'(?<=description=")[^\"]+',
          "Tensor learning compiler binary distribution"),
         (r'(?<=url=")[^\"]+', "https://tlcpack.ai")
@@ -153,6 +164,9 @@ def main():
                         default="",
                         help="Name of the produced Python packages. Optional. "
                              "Defaults to the provided build_type.")
+    parser.add_argument("--use-public-version",
+                        action="store_true",
+                        help="Set version number according to PEP-440, required for PyPI publication.")
     parser.add_argument("build_type",
                         type=str,
                         help="Type of package to be built. Use 'tlcpack' to build the last stable "

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -39,11 +39,12 @@ function audit_tlcpack_wheel() {
 
     cd "${TVM_PYTHON_DIR}" && \
       mkdir -p repared_wheel && \
-      auditwheel repair ${AUDITWHEEL_OPTS} dist/tlcpack*cp${python_version_str}*.whl
+      auditwheel repair ${AUDITWHEEL_OPTS} dist/*cp${python_version_str}*.whl
 }
 
 TVM_PYTHON_DIR="/workspace/tvm/python"
-PYTHON_VERSIONS=("3.6" "3.7" "3.8")
+PYTHON_VERSIONS_CPU=("3.6" "3.7" "3.8" "3.9" "3.10")
+PYTHON_VERSIONS_GPU=("3.6" "3.7" "3.8")
 CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
 CUDA="none"
 
@@ -77,8 +78,10 @@ fi
 
 if [[ ${CUDA} == "none" ]]; then
     echo "Building TVM for CPU only"
+    PYTHON_VERSIONS=${PYTHON_VERSIONS_CPU[*]}
 else
     echo "Building TVM with CUDA ${CUDA}"
+    PYTHON_VERSIONS=${PYTHON_VERSIONS_GPU[*]}
 fi
 
 AUDITWHEEL_OPTS="--plat ${AUDITWHEEL_PLAT} -w repaired_wheels/"


### PR DESCRIPTION
Add a new GitHub Action pipeline to run every night, to upload "CPU" (i.e. non-CUDA) packages to PyPI under apache-tvm namespace, using the latest code from 'main'.

cc @areusch @driazati