### PR TITLE
Update infrastructure to use Windows 2019

### DIFF
--- a/.github/workflows/conda_cpu_nigthly.yaml
+++ b/.github/workflows/conda_cpu_nigthly.yaml
@@ -15,7 +15,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [windows-2016, macOS-latest, ubuntu-latest]
+        os: [windows-2019, macOS-latest, ubuntu-latest]
         pkg: ['tlcpack', 'tlcpack-nightly']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -15,7 +15,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [macOS-latest, windows-2016]
+        os: [macOS-latest, windows-2019]
         pkg: ['tlcpack', 'tlcpack-nightly']
 
     runs-on: ${{ matrix.os }}

--- a/conda/recipe/bld.bat
+++ b/conda/recipe/bld.bat
@@ -6,6 +6,7 @@ mkdir build
 cd build
 
 cmake ^
+      -G "Visual Studio 16 2019" ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
       -DUSE_LLVM="llvm-config --link-static" ^

--- a/wheel/build_lib_win.bat
+++ b/wheel/build_lib_win.bat
@@ -6,6 +6,7 @@ mkdir build
 cd build
 
 cmake -A x64 -Thost=x64 ^
+      -G "Visual Studio 16 2019" ^
       -DUSE_LLVM="llvm-config --link-static" ^
       -DUSE_RPC=ON ^
       -DUSE_SORT=ON ^


### PR DESCRIPTION
GitHub says Windows 2016 is deprecate from 1st April 2022, so this patch update the infra to use Windows 2019 instead.

This is needed to unblock https://github.com/tlc-pack/tlcpack/pull/102.


cc @areusch @tqchen @Mousius for reviews