### PR TITLE
Update Windows/Mac usage of sync_package.py to Python 3

### DIFF
--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         git clone https://github.com/apache/tvm tvm --recursive
     - name: Sync Package
-      run: python common/sync_package.py ${{ matrix.pkg }}
+      run: python3 common/sync_package.py ${{ matrix.pkg }}
     - name: Build@MacOS
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}
@@ -92,5 +92,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.TLCPACK_GITHUB_TOKEN }}
       run: |
-        python -m pip install github3.py
-        python wheel/wheel_upload.py --tag v0.7.dev1 tvm/python/dist
+        python3 -m pip install github3.py
+        python3 wheel/wheel_upload.py --tag v0.7.dev1 tvm/python/dist


### PR DESCRIPTION
Currently used `python` binary causes this script to be run with Python 2 (default on Mac). This patch updates to use Python 3.

cc @areusch @driazati @Mousius for reviews