### PR TITLE
Deprecate Python 3.6 packaging

### DIFF
--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -58,16 +58,6 @@ jobs:
     # Build wheel for three python versions
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.6
-    - name: Wheel-Build@Py36
-      env:
-        MACOSX_DEPLOYMENT_TARGET: 10.14
-      run: |
-        python -m pip install setuptools Cython wheel
-        cd tvm/python
-        python setup.py bdist_wheel
-    - uses: actions/setup-python@v2
-      with:
         python-version: 3.7
     - name: Wheel-Build@Py37
       env:

--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -29,7 +29,6 @@ RUN bash /install/centos_install_arm_compute_library.sh
 
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
-RUN bash /install/centos_install_python_package.sh 3.6
 RUN bash /install/centos_install_python_package.sh 3.7
 RUN bash /install/centos_install_python_package.sh 3.8
 

--- a/docker/Dockerfile.package-cu100
+++ b/docker/Dockerfile.package-cu100
@@ -29,7 +29,6 @@ RUN bash /install/centos_install_arm_compute_library.sh
 
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
-RUN bash /install/centos_install_python_package.sh 3.6
 RUN bash /install/centos_install_python_package.sh 3.7
 RUN bash /install/centos_install_python_package.sh 3.8
 

--- a/docker/Dockerfile.package-cu101
+++ b/docker/Dockerfile.package-cu101
@@ -29,7 +29,6 @@ RUN bash /install/centos_install_arm_compute_library.sh
 
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
-RUN bash /install/centos_install_python_package.sh 3.6
 RUN bash /install/centos_install_python_package.sh 3.7
 RUN bash /install/centos_install_python_package.sh 3.8
 

--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -7,11 +7,10 @@ set -o pipefail
 # install python and pip, don't modify this, modify install_python_package.sh
 apt-get update
 apt-get install -y software-properties-common
-apt-get install -y python3.6-dev python3.7-dev python3.8-dev python3-setuptools
+apt-get install -y python3.7-dev python3.8-dev python3-setuptools
 
 # Install pip & pin pip version
 cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py
-python3.6 get-pip.py && pip3.6 install pip==19.3.1
 python3.7 get-pip.py && pip3.7 install pip==19.3.1
 python3.8 get-pip.py && pip3.8 install pip==19.3.1
 

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -43,8 +43,8 @@ function audit_tlcpack_wheel() {
 }
 
 TVM_PYTHON_DIR="/workspace/tvm/python"
-PYTHON_VERSIONS_CPU=("3.6" "3.7" "3.8" "3.9" "3.10")
-PYTHON_VERSIONS_GPU=("3.6" "3.7" "3.8")
+PYTHON_VERSIONS_CPU=("3.7" "3.8" "3.9" "3.10")
+PYTHON_VERSIONS_GPU=("3.7" "3.8")
 CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
 CUDA="none"
 


### PR DESCRIPTION
As Python 3.6 reached EOL status in 31/dec/2021, we are now phasing out packaging for this Python version.

cc @tqchen @driazati @areusch @Mousius 

closes #107