### PR TITLE
Consolidate node names

### DIFF
--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -82,7 +82,7 @@ def init_git() {
 
 
 pipeline {
-  agent { node { label 'CPU-DOCKER' } }
+  agent { node { label 'CPU' } }
 
 //  options {
       //timestamps()
@@ -107,7 +107,7 @@ pipeline {
   stages {
 
     stage('Prepare') {
-      agent { node { label 'CPU-DOCKER' } }
+      agent { node { label 'CPU' } }
       steps {
         ws(per_exec_ws("tvm/docker-prepare")) {
           cleanWs();
@@ -152,7 +152,7 @@ pipeline {
       parallel {
 
         stage('ci-cpu') {
-          agent { node { label 'CPU-DOCKER' } }
+          agent { node { label 'CPU' } }
           steps {
             ws(per_exec_ws("tvm/docker-ci-cpu")) {
               cleanWs();
@@ -174,7 +174,7 @@ pipeline {
         } // stage
 
         stage('ci-gpu') {
-          agent { node { label 'GPU-DOCKER' } }
+          agent { node { label 'GPU' } }
           steps {
             ws(per_exec_ws("tvm/docker-ci-gpu")) {
               cleanWs();
@@ -196,7 +196,7 @@ pipeline {
         } // stage
 
         stage('ci-lint') {
-          agent { node { label 'CPU-DOCKER' } }
+          agent { node { label 'CPU' } }
           steps {
             ws(per_exec_ws("tvm/docker-ci-lint")) {
               cleanWs();

--- a/jenkins/JenkinsFile-validate-docker-images
+++ b/jenkins/JenkinsFile-validate-docker-images
@@ -66,7 +66,7 @@ def cleanup_docker_image(image_type) {
 
 
 pipeline {
-  agent { node { label 'CPU-DOCKER' } }
+  agent { node { label 'CPU' } }
 
   environment {
       DOCKERHUB_USER = "tlcpackstaging"
@@ -135,7 +135,7 @@ pipeline {
       parallel {
 
         stage('cpu') {
-          agent { node { label 'CPU-DOCKER' } }
+          agent { node { label 'CPU' } }
           steps {
             ws(per_exec_ws("tvm/docker-ci-cpu")) {
               cleanWs();
@@ -162,7 +162,7 @@ pipeline {
         } // stage
 
         stage('gpu') {
-          agent { node { label 'GPU-DOCKER' } }
+          agent { node { label 'GPU' } }
           steps {
             ws(per_exec_ws("tvm/docker-ci-gpu")) {
               cleanWs();


### PR DESCRIPTION
This removes the `-DOCKER` suffix from the node requirements as the only
differentiation in CI nodes right now is by platform (ARM, GPU, CPU)

cc @areusch @konturn 