### PR TITLE
Revert quoting to Jenkins nightly validation job

### DIFF
--- a/jenkins/JenkinsFile-validate-docker-images
+++ b/jenkins/JenkinsFile-validate-docker-images
@@ -39,7 +39,7 @@ def retag_and_upload_to_docker_hub(image_type) {
   // happen very fast, as all the layers already exist in the
   // remote Docker registry.
 
-  sh '''
+  sh """
     docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_KEY}
 
     docker pull ${DOCKERHUB_USER}/${image_type}:${DOCKER_TAG}
@@ -49,7 +49,7 @@ def retag_and_upload_to_docker_hub(image_type) {
       ${DOCKERHUB_USER}/${image_type}:${DOCKER_VALIDATED_TAG}
 
     docker push ${DOCKERHUB_USER}/${image_type}:${DOCKER_VALIDATED_TAG}
- '''
+  """
 
 }
 


### PR DESCRIPTION
This was changed in b228de4 and partially reverted in 955de4a, but currently it is causing the validation job to fail to resolve local variables.

Example of job failing: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-validate/detail/daily-docker-image-validate/101/pipeline

cc @driazati @areusch @Mousius for reviews