### PR TITLE
Build Arduino RVM image on Jenkins

### DIFF
--- a/jenkins/JenkinsFile-rebuild-validate-rvm-images
+++ b/jenkins/JenkinsFile-rebuild-validate-rvm-images
@@ -156,6 +156,25 @@ pipeline {
           } // post
         } // stage
       } // parallel
+      stage('ci-arduino') {
+          agent { node { label 'CPU-MICROTVM' } }
+          steps {
+            ws(per_exec_ws('tvm/rvm-ci-arduino')) {
+              cleanWs()
+              init_git()
+              dir('tvm') {
+                rvm_build(arduino)
+                rvm_upload(arduino)
+              }
+            }
+          } // steps
+          post {
+            always {
+              cleanWs()
+            }
+          } // post
+        } // stage
+      } // parallel
     } // stage: Build
   } // stages
   post {

--- a/jenkins/JenkinsFile-rebuild-validate-rvm-images
+++ b/jenkins/JenkinsFile-rebuild-validate-rvm-images
@@ -155,8 +155,7 @@ pipeline {
             }
           } // post
         } // stage
-      } // parallel
-      stage('ci-arduino') {
+        stage('ci-arduino') {
           agent { node { label 'CPU-MICROTVM' } }
           steps {
             ws(per_exec_ws('tvm/rvm-ci-arduino')) {


### PR DESCRIPTION
Automatically build and upload the Arduino RVM image to the cloud hub. This change should fix the broken `spresense` test on the microtvm nightly run.