### PR TITLE
Run tests in wheel

### DIFF
--- a/.github/workflows/conda_gpu_nigthly.yaml
+++ b/.github/workflows/conda_gpu_nigthly.yaml
@@ -17,11 +17,11 @@ jobs:
         pkg: ['tlcpack', 'tlcpack-nightly']
         config:
           - cuda: '10.0'
-            image: 'tlcpack/package-cu100:v0.4'
+            image: 'tlcpack/package-cu100:v0.5'
           - cuda: '10.1'
-            image: 'tlcpack/package-cu101:v0.4'
+            image: 'tlcpack/package-cu101:v0.5'
           - cuda: '10.2'
-            image: 'tlcpack/package-cu102:v0.4'
+            image: 'tlcpack/package-cu102:v0.5'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -19,13 +19,13 @@ jobs:
         # matrix of build configs
         config:
           - cuda: 'none'
-            image: 'tlcpack/package-cpu:v0.4'
+            image: 'tlcpack/package-cpu:v0.5'
           - cuda: '10.0'
-            image: 'tlcpack/package-cu100:v0.4'
+            image: 'tlcpack/package-cu100:v0.5'
           - cuda: '10.1'
-            image: 'tlcpack/package-cu101:v0.4'
+            image: 'tlcpack/package-cu101:v0.5'
           - cuda: '10.2'
-            image: 'tlcpack/package-cu102:v0.4'
+            image: 'tlcpack/package-cu102:v0.5'
 
     runs-on: ubuntu-latest
 
@@ -42,6 +42,14 @@ jobs:
         CUDA: ${{ matrix.config.cuda }}
       run: |
         docker/bash.sh --no-gpu $IMAGE ./wheel/build_wheel_manylinux.sh --cuda $CUDA
+    - name: Test
+      if: matrix.config.cuda == 'none'
+      env:
+        IMAGE: ${{ matrix.config.image }}
+        WHEEL_TEST: "True"
+      continue-on-error: true
+      run: |
+        docker/bash.sh --no-gpu $IMAGE ./wheel/run_tests.sh
     - name: Wheel-Deploy
       if: github.ref == 'refs/heads/main'
       env:

--- a/.github/workflows/wheel_manylinux_pypi.yaml
+++ b/.github/workflows/wheel_manylinux_pypi.yaml
@@ -20,7 +20,7 @@ jobs:
         # matrix of build configs
         config:
           - cuda: 'none'
-            image: 'tlcpack/package-cpu:v0.4'
+            image: 'tlcpack/package-cpu:v0.5'
             package_name: 'apache-tvm'
 
     runs-on: ubuntu-latest
@@ -43,6 +43,14 @@ jobs:
         CUDA: ${{ matrix.config.cuda }}
       run: |
         docker/bash.sh --no-gpu $IMAGE ./wheel/build_wheel_manylinux.sh --cuda $CUDA
+    - name: Test
+      if: matrix.config.cuda == 'none'
+      env:
+        IMAGE: ${{ matrix.config.image }}
+        WHEEL_TEST: "True"
+      continue-on-error: true
+      run: |
+        docker/bash.sh --no-gpu $IMAGE ./wheel/run_tests.sh
     - name: Wheel-Deploy-Pypi
       if: github.ref == 'refs/heads/main'
       env:

--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -27,6 +27,11 @@ RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
 RUN bash /install/centos_install_arm_compute_library.sh
 
+# Install Conda
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+ENV PATH=/opt/conda/bin:${PATH}
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.7
@@ -34,10 +39,4 @@ RUN bash /install/centos_install_python_package.sh 3.8
 
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
-
-COPY install/centos_install_conda.sh /install/centos_install_conda.sh
-RUN bash /install/centos_install_conda.sh
-
-# Environment variables
-ENV PATH=/opt/conda/bin:${PATH}
 ENV AUDITWHEEL_PLAT=manylinux2014_x86_64

--- a/docker/Dockerfile.package-cu100
+++ b/docker/Dockerfile.package-cu100
@@ -27,6 +27,11 @@ RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
 RUN bash /install/centos_install_arm_compute_library.sh
 
+# Install Conda
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+ENV PATH=/opt/conda/bin:${PATH}
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.7
@@ -35,11 +40,8 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
-COPY install/centos_install_conda.sh /install/centos_install_conda.sh
-RUN bash /install/centos_install_conda.sh
-
 # Environment variables
-ENV PATH=/usr/local/cuda/bin:/opt/conda/bin:${PATH}
+ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}
 ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LIBRARY_PATH}

--- a/docker/Dockerfile.package-cu101
+++ b/docker/Dockerfile.package-cu101
@@ -27,6 +27,11 @@ RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
 RUN bash /install/centos_install_arm_compute_library.sh
 
+# Install Conda
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+ENV PATH=/opt/conda/bin:${PATH}
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.7
@@ -35,12 +40,8 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
-COPY install/centos_install_conda.sh /install/centos_install_conda.sh
-RUN bash /install/centos_install_conda.sh
-
-
 # Environment variables
-ENV PATH=/usr/local/cuda/bin:/opt/conda/bin:${PATH}
+ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}
 ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LIBRARY_PATH}

--- a/docker/Dockerfile.package-cu102
+++ b/docker/Dockerfile.package-cu102
@@ -27,6 +27,11 @@ RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
 COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
 RUN bash /install/centos_install_arm_compute_library.sh
 
+# Install Conda
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+ENV PATH=/opt/conda/bin:${PATH}
+
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
 RUN bash /install/centos_install_python_package.sh 3.7
@@ -35,12 +40,8 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
-COPY install/centos_install_conda.sh /install/centos_install_conda.sh
-RUN bash /install/centos_install_conda.sh
-
-
 # Environment variables
-ENV PATH=/usr/local/cuda/bin:/opt/conda/bin:${PATH}
+ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}
 ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LIBRARY_PATH}

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -48,6 +48,11 @@ else
     CUDA_ENV=""
 fi
 
+# If this is an wheel test command then pass the env var to docker.
+if [[ ! -z $WHEEL_TEST ]]; then
+    WHEEL_TEST="-e WHEEL_TEST=${WHEEL_TEST}"
+fi
+
 if [[ "${DOCKER_IMAGE_NAME}" == *"cu"* ]]; then
     if [ "$ENABLE_NV_DOCKER" -eq 1 ]; then
         if ! type "nvidia-docker" 1> /dev/null 2> /dev/null
@@ -80,6 +85,7 @@ ${DOCKER_BINARY} run --rm --pid=host\
     -v ${SCRIPT_DIR}:/docker \
     -w /workspace \
     ${CUDA_ENV} \
+    ${WHEEL_TEST} \
     ${DOCKER_EXTRA_PARAMS[@]} \
     ${DOCKER_IMAGE_NAME} \
     ${COMMAND[@]}

--- a/docker/install/centos_install_python_package.sh
+++ b/docker/install/centos_install_python_package.sh
@@ -11,6 +11,9 @@ CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} ${UNICODE_WIDTH})"
 PIP="${CPYTHON_PATH}/bin/pip"
 
 PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
-orderedset antlr4-python3-runtime attrs requests Pillow packaging"
+orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 ${PIP} install ${PYTHON_PACKAGES}
+
+# Also install dependencies with the conda environment.
+pip install ${PYTHON_PACKAGES}

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -5,7 +5,7 @@ set -u
 set -o pipefail
 
 PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
-orderedset antlr4-python3-runtime attrs requests Pillow packaging"
+orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 # install libraries for python package on ubuntu
 pip3.6 install ${PYTHON_PACKAGES}

--- a/wheel/run_tests.sh
+++ b/wheel/run_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /workspace/tvm
+
+bash tests/scripts/task_python_unittest.sh


### PR DESCRIPTION
This PR runs the python unit tests as part of the nightly build. 

Since at the moment there are some failing tests, I do an `|| true` to ignore the return code of the `run_tests.sh` command and [keep the green tick-mark](https://github.com/actions/toolkit/issues/399) in the actions section.

@areusch 