### PR TITLE
Move `apache-tvm` PyPI package cadence to be weekly

### DIFF
--- a/.github/workflows/wheel_manylinux_pypi.yaml
+++ b/.github/workflows/wheel_manylinux_pypi.yaml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 5 * * *' # 5 AM UTC
+    - cron: '0 5 * 3 *' # Every Wed 5 AM UTC
 
 jobs:
   Build:

--- a/.github/workflows/wheel_manylinux_pypi.yaml
+++ b/.github/workflows/wheel_manylinux_pypi.yaml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 5 * 3 *' # Every Wed 5 AM UTC
+    - cron: '0 5 * * 3' # Every Wed 5 AM UTC
 
 jobs:
   Build:


### PR DESCRIPTION
Using a nightly cadence to publish packages on PyPI made our quota to run out in about 3 months, so I'm changing the cadence to be weekly, so that we can have a regular "dev drop", while we try to negotiate a bump in our quota.

This only applies to packages published on PyPI https://pypi.org/manage/project/apache-tvm/releases/ which I manually cleaned up to keep one build per week since April/2022.

cc @areusch