### PR TITLE
[CUDA] Deprecate 10.0/10.1 and add 11.0/11.1/11.3

### DIFF
--- a/.github/workflows/conda_gpu_nigthly.yaml
+++ b/.github/workflows/conda_gpu_nigthly.yaml
@@ -16,12 +16,14 @@ jobs:
       matrix:
         pkg: ['tlcpack', 'tlcpack-nightly']
         config:
-          - cuda: '10.0'
-            image: 'tlcpack/package-cu100:v0.5'
-          - cuda: '10.1'
-            image: 'tlcpack/package-cu101:v0.5'
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:v0.5'
+          - cuda: '11.0'
+            image: 'tlcpack/package-cu110:v0.1'
+          - cuda: '11.1'
+            image: 'tlcpack/package-cu111:v0.1'
+          - cuda: '11.3'
+            image: 'tlcpack/package-cu113:v0.1'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -20,12 +20,14 @@ jobs:
         config:
           - cuda: 'none'
             image: 'tlcpack/package-cpu:v0.5'
-          - cuda: '10.0'
-            image: 'tlcpack/package-cu100:v0.5'
-          - cuda: '10.1'
-            image: 'tlcpack/package-cu101:v0.5'
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:v0.5'
+          - cuda: '11.0'
+            image: 'tlcpack/package-cu110:v0.1'
+          - cuda: '11.1'
+            image: 'tlcpack/package-cu111:v0.1'
+          - cuda: '11.3'
+            image: 'tlcpack/package-cu113:v0.1'
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ will point to a stable build hashtag defined in common/sync_package.py
 ./docker/bash.sh [docker-image] ./wheel/build_wheel_manylinux.sh --cuda none
 ```
 
-To build wheels for a specific CUDA version, for example, CUDA 10.1, run
+To build wheels for a specific CUDA version, for example, CUDA 11.1, run
 
 ```bash
-./docker/bash.sh [docker-image] ./wheel/build_wheel_manylinux.sh --cuda 10.1
+./docker/bash.sh [docker-image] ./wheel/build_wheel_manylinux.sh --cuda 11.1
 ```
 
 The docker image is built in step 1 and needs to match the cuda version.

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -156,7 +156,7 @@ def main():
     parser.add_argument("--cuda",
                         type=str,
                         default="none",
-                        choices=["none", "10.0", "10.1", "10.2"],
+                        choices=["none", "10.2", "11.0", "11.1", "11.3"],
                         help="CUDA version to be linked to the resultant binaries,"
                              "or none, to disable CUDA. Defaults to none.")
     parser.add_argument("--package-name",

--- a/docker/Dockerfile.package-cu110
+++ b/docker/Dockerfile.package-cu110
@@ -1,6 +1,6 @@
-# Docker image: tlcpack/package-cu101
+# Docker image: tlcpack/package-cu110
 
-FROM pytorch/manylinux-cuda101
+FROM pytorch/manylinux-cuda110
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh

--- a/docker/Dockerfile.package-cu111
+++ b/docker/Dockerfile.package-cu111
@@ -1,0 +1,49 @@
+# Docker image: tlcpack/package-cu111
+
+FROM pytorch/manylinux-cuda111
+
+# install core
+COPY install/centos_install_core.sh /install/centos_install_core.sh
+RUN bash /install/centos_install_core.sh
+
+# install cmake
+COPY install/centos_install_cmake.sh /install/centos_install_cmake.sh
+RUN bash /install/centos_install_cmake.sh
+
+# build llvm
+COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
+RUN bash /install/centos_build_llvm.sh 10.0
+
+# upgrade patchelf due to the bug in patchelf 0.10
+# see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected
+COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
+RUN bash /install/centos_install_patchelf.sh
+
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
+# Install Conda
+COPY install/centos_install_conda.sh /install/centos_install_conda.sh
+RUN bash /install/centos_install_conda.sh
+ENV PATH=/opt/conda/bin:${PATH}
+
+# install python packages
+COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
+RUN bash /install/centos_install_python_package.sh 3.7
+RUN bash /install/centos_install_python_package.sh 3.8
+
+COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
+RUN bash /install/centos_install_auditwheel.sh
+
+# Environment variables
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}
+ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
+ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compact:${LD_LIBRARY_PATH}
+ENV AUDITWHEEL_PLAT=manylinux2014_x86_64

--- a/docker/Dockerfile.package-cu113
+++ b/docker/Dockerfile.package-cu113
@@ -1,6 +1,6 @@
-# Docker image: tlcpack/package-cu100
+# Docker image: tlcpack/package-cu113
 
-FROM pytorch/manylinux-cuda100
+FROM pytorch/manylinux-cuda113
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -6,7 +6,7 @@
 # Usage: build_image.sh <CONTAINER_TYPE>
 #
 # CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,
-#                 (cpu|cu100|cu101|cu102)
+#                 (cpu|cu102|cu110|cu111|cu113)
 #
 # The built image will show as tlpack/package-[type]:staging
 #

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -5,7 +5,7 @@ source /multibuild/manylinux_utils.sh
 function usage() {
     echo "Usage: $0 [--cuda CUDA]"
     echo
-    echo -e "--cuda {none 10.0 10.1 10.2}"
+    echo -e "--cuda {none 10.2 11.0 11.1 11.3}"
     echo -e "\tSpecify the CUDA version in the TVM (default: none)."
 }
 
@@ -45,7 +45,7 @@ function audit_tlcpack_wheel() {
 TVM_PYTHON_DIR="/workspace/tvm/python"
 PYTHON_VERSIONS_CPU=("3.7" "3.8" "3.9" "3.10")
 PYTHON_VERSIONS_GPU=("3.7" "3.8")
-CUDA_OPTIONS=("none" "10.0" "10.1" "10.2")
+CUDA_OPTIONS=("none" "10.2" "11.0" "11.1" "11.3")
 CUDA="none"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Closing #120 

@areusch please let me know if we need to manually build and push the docker images for CUDA 11 series. Also, I'm not sure if we need to change the version set in the TLCPack website manually?