### PR TITLE
[CUDA] Fix manylinux build

### DIFF
--- a/docker/Dockerfile.package-cu110
+++ b/docker/Dockerfile.package-cu110
@@ -40,6 +40,9 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
+# Set default CUDA
+RUN rm /usr/local/cuda; ln -s /usr/local/cuda-11.0 /usr/local/cuda
+
 # Environment variables
 ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}

--- a/docker/Dockerfile.package-cu111
+++ b/docker/Dockerfile.package-cu111
@@ -40,6 +40,9 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
+# Set default CUDA
+RUN rm /usr/local/cuda; ln -s /usr/local/cuda-11.1 /usr/local/cuda
+
 # Environment variables
 ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}

--- a/docker/Dockerfile.package-cu113
+++ b/docker/Dockerfile.package-cu113
@@ -40,6 +40,9 @@ RUN bash /install/centos_install_python_package.sh 3.8
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh
 
+# Set default CUDA
+RUN rm /usr/local/cuda; ln -s /usr/local/cuda-11.3 /usr/local/cuda
+
 # Environment variables
 ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:${CPLUS_INCLUDE_PATH}


### PR DESCRIPTION
I checked the errors in the latest pip build and the root cause should be just the CUDA path. Without explicitly pointing to the right CUDA version, Cmake will still find CUDA 10.2 in these images.

Meanwhile, I tried to debug the conda build failure, but I could only say it should be due to the difference conda environment in these images, but I have no idea how to resolve them.

cc @areusch @tqchen 