### PR TITLE
Add support for AArch64 wheel Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Checkout [.github/workflows](.github/workflows)
 ```bash
 ./docker/build_image.sh <CONTAINER_TYPE>
 
-CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cu100|cu101|cu102)
+CONTAINER_NAME: Type of the docker container used to build wheels, e.g., (cpu|cpu_aarch64|cu100|cu101|cu102)
 ```
 
 2. Checkout tvm and sync version

--- a/docker/Dockerfile.package-cpu_aarch64
+++ b/docker/Dockerfile.package-cpu_aarch64
@@ -1,0 +1,41 @@
+# Docker image: tlcpack/package-cpu_aarch64
+
+FROM quay.io/pypa/manylinux2014_aarch64:2022-07-27-a8099af
+
+# install core
+COPY install/centos_install_core_aarch64.sh /install/centos_install_core_aarch64.sh
+RUN bash /install/centos_install_core_aarch64.sh
+
+# install cmake
+COPY install/centos_install_cmake.sh /install/centos_install_cmake.sh
+RUN bash /install/centos_install_cmake.sh
+
+# build llvm
+COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
+RUN bash /install/centos_build_llvm.sh 10.0
+
+# upgrade patchelf due to the bug in patchelf 0.10
+# see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected
+COPY install/centos_install_patchelf.sh /install/centos_install_patchelf.sh
+RUN bash /install/centos_install_patchelf.sh
+
+# Install Arm Ethos-N NPU driver stack
+COPY install/centos_install_arm_ethosn_driver_stack.sh /install/centos_install_arm_ethosn_driver_stack.sh
+RUN bash /install/centos_install_arm_ethosn_driver_stack.sh
+
+# Install Compute Library for Arm(r) Architecture (ACL)
+COPY install/centos_install_arm_compute_library.sh /install/centos_install_arm_compute_library.sh
+RUN bash /install/centos_install_arm_compute_library.sh
+
+# install python packages
+COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
+RUN bash /install/centos_install_python_package.sh 3.6
+RUN bash /install/centos_install_python_package.sh 3.7
+RUN bash /install/centos_install_python_package.sh 3.8
+
+COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
+RUN bash /install/centos_install_auditwheel.sh
+
+# Environment variables
+ENV PATH=/opt/conda/bin:${PATH}
+ENV AUDITWHEEL_PLAT=manylinux2014_aarch64

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -6,7 +6,7 @@
 # Usage: build_image.sh <CONTAINER_TYPE>
 #
 # CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,
-#                 (cpu|cu102|cu110|cu111|cu113)
+#                 (cpu|cpu_aarch64|cu102|cu110|cu111|cu113)
 #
 # The built image will show as tlpack/package-[type]:staging
 #
@@ -15,7 +15,7 @@ if [[ $# -lt 1 ]]; then
     echo "$0 <CONTAINER_TYPE>"
     echo
     echo "CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,"
-    echo "                (cpu|cu100|cu101|cu102)"
+    echo "                (cpu|cpu_aarch64|cu100|cu101|cu102)"
     exit -1
 fi
 

--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -13,7 +13,7 @@ install_path="/opt/arm/$repo_dir"
 tmpdir=$(mktemp -d)
 
 # install dependencies for building Arm(r) Ethos(tm)-N series Driver Stack
-yum install -y sparse bc devtoolset-7-gcc-c++ wget
+yum install -y bc devtoolset-7-gcc-c++ wget
 
 source /opt/rh/devtoolset-7/enable
 

--- a/docker/install/centos_install_core_aarch64.sh
+++ b/docker/install/centos_install_core_aarch64.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+# install libraries for building c++ core on ubuntu
+yum install -y wget xz python3-pip
+
+# install multibuild utils
+git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && \
+    git checkout 9e2349833e994cb829b77cc08f1aacc6ab6d2458
+
+# install argparse
+pip3 install argparse


### PR DESCRIPTION
Add support to generate native AArch64 packages with TVM. It was tested to generate cpu targeted wheel packages using
`manylinux2014_aarch64` on AArch64. We still can't produce these natively as GitHub Actions doesn't support AArch64.

cc @driazati @areusch @Mousius @tqchen 