### PR TITLE
[ETHOSN] Update NPU driver stack to v22.08

### DIFF
--- a/docker/install/centos_install_arm_ethosn_driver_stack.sh
+++ b/docker/install/centos_install_arm_ethosn_driver_stack.sh
@@ -7,7 +7,7 @@ python3_bin="$(cpython_path 3.7)/bin/python"
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"
-repo_revision="22.05"
+repo_revision="22.08"
 install_path="/opt/arm/$repo_dir"
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
Updates the driver stack version to v22.08.

~Note: marking as WIP as this is dependent on https://github.com/apache/tvm/pull/12650~

cc @leandron 