### PR TITLE
Increases LLVM releases version results from GitHub API

### DIFF
--- a/docker/install/centos_build_llvm.sh
+++ b/docker/install/centos_build_llvm.sh
@@ -7,7 +7,7 @@ LLVM_VERSION_MAJOR=$1
 source /multibuild/manylinux_utils.sh
 
 detect_llvm_version() {
-  curl -sL "https://api.github.com/repos/llvm/llvm-project/releases?per_page=50" | \
+  curl -sL "https://api.github.com/repos/llvm/llvm-project/releases?per_page=100" | \
     grep tag_name | \
     grep -o "llvmorg-${LLVM_VERSION_MAJOR}[^\"]*" | \
     grep -v rc | \


### PR DESCRIPTION
We are currently using GitHub API to discover what is the latest 10.0.x minor release in LLVM. As LLVM now releases a few more versions the number of results we are retrieving (50) is not enough.

This patch increases the number of results to 100, so that we can get the information we need.

Sample URLs:

- 50 results (does not cover 10.0.x): https://api.github.com/repos/llvm/llvm-project/releases?per_page=50
- 100 results (cover 10.0.x): https://api.github.com/repos/llvm/llvm-project/releases?per_page=100

Suggested search `LLVM 10.0`.

cc @Mousius @tqchen @areusch @driazati 