### PR TITLE
[Docker] Use up-to-date version of CMake an all images

### DIFF
--- a/docker/install/centos_install_cmake.sh
+++ b/docker/install/centos_install_cmake.sh
@@ -6,4 +6,6 @@ set -o pipefail
 
 /opt/python/cp37-cp37m/bin/pip install cmake ninja
 ln -s /opt/python/cp37-cp37m/bin/ninja /usr/local/bin/ninja
+rm -f /usr/local/bin/cmake
+ln -s /opt/python/cp37-cp37m/bin/cmake /usr/local/bin/cmake
 strip /opt/_internal/cpython-3.*/lib/python3.7/site-packages/cmake/data/bin/*


### PR DESCRIPTION
See #138.

As mentioned, to fix the CI, the newly build images also have to be tagged and used in the workflows.

cc @Mousius @tqchen @driazati @leandron 