### PR TITLE
[Docker] Use pytorch base images for tlcpack/package-cpu to fix manylinux2014 compliance

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -1,6 +1,6 @@
 # Docker image: tlcpack/package-cpu
 
-FROM quay.io/pypa/manylinux2014_x86_64:2022-02-13-594988e
+FROM pytorch/manylinux-cpu
 
 # install core
 COPY install/centos_install_core.sh /install/centos_install_core.sh


### PR DESCRIPTION
Should resolve #142.

Once merged, I will do a followup PR hopefully fixing #141 and #138 as well.