### PR TITLE
Fix remaining CI Errors

### DIFF
--- a/.github/workflows/conda_gpu_nigthly.yaml
+++ b/.github/workflows/conda_gpu_nigthly.yaml
@@ -18,8 +18,9 @@ jobs:
         config:
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:7bfdf7e'
-          - cuda: '11.0'
-            image: 'tlcpack/package-cu110:7bfdf7e'
+          # Conda forge is not shipping a cudnn package with support for CUDA 11.0
+          # - cuda: '11.0'
+          #   image: 'tlcpack/package-cu110:7bfdf7e'
           - cuda: '11.1'
             image: 'tlcpack/package-cu111:7bfdf7e'
           - cuda: '11.3'

--- a/.github/workflows/conda_gpu_nigthly.yaml
+++ b/.github/workflows/conda_gpu_nigthly.yaml
@@ -25,6 +25,8 @@ jobs:
             image: 'tlcpack/package-cu111:7bfdf7e'
           - cuda: '11.3'
             image: 'tlcpack/package-cu113:7bfdf7e'
+          - cuda: '11.6'
+            image: 'tlcpack/package-cu116:7bfdf7e'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker_images.yaml
+++ b/.github/workflows/docker_images.yaml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - cpu
           - cu102
-          - cu110
+          # - cu110
           - cu111
           - cu113
           - cu116

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -22,12 +22,16 @@ jobs:
             image: 'tlcpack/package-cpu:7bfdf7e'
           - cuda: '10.2'
             image: 'tlcpack/package-cu102:7bfdf7e'
-          - cuda: '11.0'
-            image: 'tlcpack/package-cu110:7bfdf7e'
+          # CUDA 11.0 is not supported for Conda build,
+          # Let's drop support here as well.
+          # - cuda: '11.0'
+          #   image: 'tlcpack/package-cu110:7bfdf7e'
           - cuda: '11.1'
             image: 'tlcpack/package-cu111:7bfdf7e'
           - cuda: '11.3'
             image: 'tlcpack/package-cu113:7bfdf7e'
+          - cuda: '11.6'
+            image: 'tlcpack/package-cu116:7bfdf7e'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -57,5 +57,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.TLCPACK_GITHUB_TOKEN }}
       run: |
+        python -m pip install pyOpenSSL --upgrade
         python -m pip install github3.py
         python wheel/wheel_upload.py --tag v0.7.dev1 tvm/python/repaired_wheels

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -156,7 +156,7 @@ def main():
     parser.add_argument("--cuda",
                         type=str,
                         default="none",
-                        choices=["none", "10.2", "11.1", "11.3"],
+                        choices=["none", "10.2", "11.1", "11.3", "11.6"],
                         help="CUDA version to be linked to the resultant binaries,"
                              "or none, to disable CUDA. Defaults to none.")
     parser.add_argument("--package-name",

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -8,7 +8,7 @@ import argparse
 # Modify the following two settings during release
 # -----------------------------------------------------------
 # Tag used for stable build.
-__stable_build__ = "v0.9.0"
+__stable_build__ = "v0.10.0"
 # -----------------------------------------------------------
 
 def py_str(cstr):

--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -156,7 +156,7 @@ def main():
     parser.add_argument("--cuda",
                         type=str,
                         default="none",
-                        choices=["none", "10.2", "11.0", "11.1", "11.3"],
+                        choices=["none", "10.2", "11.1", "11.3"],
                         help="CUDA version to be linked to the resultant binaries,"
                              "or none, to disable CUDA. Defaults to none.")
     parser.add_argument("--package-name",

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -47,10 +47,10 @@ outputs:
         - zlib
         - llvmdev ==10.0.0
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - cudnn >=7.6.0 # [cuda]
       run:
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - cudnn >=7.6.0 # [cuda]
 
   - name: {{ pkg_name }}
     script: install_python_pkg.sh  # [not win]

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -6,7 +6,7 @@
 # Usage: build_image.sh <CONTAINER_TYPE>
 #
 # CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,
-#                 (cpu|cpu_aarch64|cu102|cu110|cu111|cu113)
+#                 (cpu|cpu_aarch64|cu102|cu111|cu113|cu116)
 #
 # The built image will show as tlpack/package-[type]:staging
 #
@@ -15,7 +15,7 @@ if [[ $# -lt 1 ]]; then
     echo "$0 <CONTAINER_TYPE>"
     echo
     echo "CONTAINER_NAME: Type of the docker container used to build wheels, e.g.,"
-    echo "                (cpu|cpu_aarch64|cu100|cu101|cu102)"
+    echo "                (cpu|cpu_aarch64|cu102|cu111|cu113|cu116)"
     exit -1
 fi
 

--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -5,7 +5,7 @@ source /multibuild/manylinux_utils.sh
 function usage() {
     echo "Usage: $0 [--cuda CUDA]"
     echo
-    echo -e "--cuda {none 10.2 11.0 11.1 11.3}"
+    echo -e "--cuda {none 10.2 11.1 11.3 11.6}"
     echo -e "\tSpecify the CUDA version in the TVM (default: none)."
 }
 
@@ -39,7 +39,7 @@ function audit_tlcpack_wheel() {
 TVM_PYTHON_DIR="/workspace/tvm/python"
 PYTHON_VERSIONS_CPU=("3.7" "3.8" "3.9" "3.10")
 PYTHON_VERSIONS_GPU=("3.7" "3.8")
-CUDA_OPTIONS=("none" "10.2" "11.0" "11.1" "11.3")
+CUDA_OPTIONS=("none" "10.2" "11.1" "11.3" "11.6")
 CUDA="none"
 
 while [[ $# -gt 0 ]]; do
@@ -66,7 +66,7 @@ done
 if ! in_array "${CUDA}" "${CUDA_OPTIONS[*]}" ; then
     echo "Invalid CUDA option: ${CUDA}"
     echo
-    echo 'CUDA can only be {"none", "10.0", "10.1", "10.2"}'
+    echo 'CUDA can only be {"none", "10.2", "11.1", "11.3", "11.6"}'
     exit -1
 fi
 


### PR DESCRIPTION
- Fixed Conda builds by Increasing the allowed version of the CUDNN package and dropping support for CUDA 11.0
- Enable builds for CUDA 11.6 (not tested yet)
- Fix final issue with manylinux nightly builds
- For consistency drop CUDA 11.0 support for other workflows as well

MacOS errors are covered in #140.