### PR TITLE
[CI] fix broken handling of release candidates in wheel_prune_and_sync.py script

### DIFF
--- a/wheel/wheel_prune_and_sync.py
+++ b/wheel/wheel_prune_and_sync.py
@@ -44,10 +44,18 @@ def extract_group_key_order(name):
 
     dev_pos = ver.find(".dev")
     if dev_pos != -1:
+        rc_pos = ver.find("rc")
         # all nightly share the same group
         group_key.append("nightly")
         # dev number as the order.
-        pub_ver = [int(x) for x in ver[:dev_pos].split(".")]
+        pos = dev_pos
+        if rc_pos != -1:
+            pos = rc_pos
+        pub_ver = [int(x) for x in ver[:pos].split(".")]
+        if rc_pos != -1:
+            pub_ver += [int(ver[rc_pos + 2 : dev_pos])]
+        else:
+            pub_ver += [int(1e9)]
         order = pub_ver + [int(ver[dev_pos + 4 :])]
     else:
         # stable version has its own group


### PR DESCRIPTION
It seems like the "Prune-Nightly" job broke yesterday: https://github.com/tlc-pack/tlcpack/actions/runs/3327332266/jobs/5502020456

```
Traceback (most recent call last):
  File "/home/runner/work/tlcpack/tlcpack/wheel/wheel_prune_and_sync.py", line 172, in <module>
    main()
  File "/home/runner/work/tlcpack/tlcpack/wheel/wheel_prune_and_sync.py", line 163, in main
    group_map = group_wheels(wheels)
  File "/home/runner/work/tlcpack/tlcpack/wheel/wheel_prune_and_sync.py", line 63, in group_wheels
    gkey, order = extract_group_key_order(asset.name)
  File "/home/runner/work/tlcpack/tlcpack/wheel/wheel_prune_and_sync.py", line 50, in extract_group_key_order
    pub_ver = [int(x) for x in ver[:dev_pos].split(".")]
  File "/home/runner/work/tlcpack/tlcpack/wheel/wheel_prune_and_sync.py", line 50, in <listcomp>
    pub_ver = [int(x) for x in ver[:dev_pos].split(".")]
ValueError: invalid literal for int() with base 10: '0rc0'
```

See:

This should allow the script to deal with `rc`s in the version numbers.

@driazati 