### PR TITLE
[CI] fix broken handling of release candidates in anaconda_prune.py

### DIFF
--- a/conda/anaconda_prune.py
+++ b/conda/anaconda_prune.py
@@ -51,10 +51,18 @@ def extract_group_key_order(path):
 
     dev_pos = ver.find(".dev")
     if dev_pos != -1:
+        rc_pos = ver.find("rc")
         # all nightly share the same group
         group_key.append("nightly")
         # dev number as the order.
-        pub_ver = [int(x) for x in ver[:dev_pos].split(".")]
+        pos = dev_pos
+        if rc_pos != -1:
+            pos = rc_pos
+        pub_ver = [int(x) for x in ver[:pos].split(".")]
+        if rc_pos != -1:
+            pub_ver += [int(ver[rc_pos + 2 : dev_pos])]
+        else:
+            pub_ver += [int(1e9)]
         order = pub_ver + [int(ver[dev_pos + 4 :])] + order
     else:
         # stable version has its own group


### PR DESCRIPTION
Had to port #146 to Conda as well to fix CI.

HOWEVER I found the actual cause of that RC-related issues:

The rc tag for the latest TVM should be `v0.10.rc0` Instead of `v0.10.0rc0`. Renaming that tag leads to the expected behavior for nightly builds based on the `v0.10.dev0` instead of `v0.10.0rc0`.

@tqchen Should we really add a workaround to deal with that mistake/inconsistency or just recreate the tag in the upstream repo with the proper name?