### PR TITLE
Fix Python version check when Conda not installed

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -115,10 +115,17 @@ UNICODE_WIDTH=32  # Dummy value, irrelevant for Python 3
 for python_version in ${PYTHON_VERSIONS[*]}
 do
     echo "> Looking for Python ${python_version}."
-    
+
     # Remove the . in version string, e.g. "3.8" turns into "38"
     python_version_str="$(echo "${python_version}" | sed -r 's/\.//g')"
     cpython_dir="/opt/conda/envs/py${python_version_str}/"
+
+    # For compatibility in environments where Conda is not installed,
+    # revert back to previous method of locating cpython_dir.
+    if ! [ -d "${cpython_dir}" ]; then
+      cpython_dir=$(cpython_path "${python_version}" "${UNICODE_WIDTH}" 2> /dev/null)
+    fi
+
     if [ -d "${cpython_dir}" ]; then
       echo "Generating package for Python ${python_version}."
       build_tlcpack_wheel ${cpython_dir}


### PR DESCRIPTION
When running tlcpack on build environments that do not have Conda installed, the script is failing due to the method used to locate the Python version.

5382fa075932676938728a241e21bfcb8e714ea1 changed the way in which the Python version is located, now hard-coding a path that only exists in environments where Conda has been installed.

I have added a check to fall back to the previous method of locating the Python version on environments where Conda is not installed.

CC @leandron @driazati @areusch @Mousius for review