### PR TITLE
Add logic to skip the Git checkout

### DIFF
--- a/common/sync_package.py
+++ b/common/sync_package.py
@@ -159,6 +159,10 @@ def main():
                         choices=["none", "10.2", "11.1", "11.3", "11.6"],
                         help="CUDA version to be linked to the resultant binaries,"
                              "or none, to disable CUDA. Defaults to none.")
+    parser.add_argument("--skip-checkout",
+                        action="store_true",
+                        help="Run the syncronization process without checking out new source."
+                             "For use when running in an existing checkout.")
     parser.add_argument("--package-name",
                         type=str,
                         default="",
@@ -175,10 +179,11 @@ def main():
 
     package_name = args.package_name or args.build_type
 
-    if "nightly" not in args.build_type:
-        checkout_source(args.src, __stable_build__)
-    else:
-        checkout_source(args.src, args.revision)
+    if not args.skip_checkout:
+        if "nightly" not in args.build_type:
+            checkout_source(args.src, __stable_build__)
+        else:
+            checkout_source(args.src, args.revision)
 
     update_libinfo(args)
     update_setup(args, package_name)


### PR DESCRIPTION
In some circumstances we would like to skip the checkout stage, in order to run the package sync on an existing checkout.

In this case it is not necessary and in some cases, undesirable to run the checkout again so this patch adds logic to bypass it when required.

Unless the --skip-checkout option is passed, existing checkout logic remains unchanged by this patch.

CC @leandron @areusch @Mousius @driazati for review