### PR TITLE
[Python] Enable Python 3.11 packaging where available for CPU builds

### DIFF
--- a/wheel/build_wheel_manylinux.sh
+++ b/wheel/build_wheel_manylinux.sh
@@ -37,7 +37,7 @@ function audit_tlcpack_wheel() {
 }
 
 TVM_PYTHON_DIR="/workspace/tvm/python"
-PYTHON_VERSIONS_CPU=("3.7" "3.8" "3.9" "3.10")
+PYTHON_VERSIONS_CPU=("3.7" "3.8" "3.9" "3.10" "3.11")
 PYTHON_VERSIONS_GPU=("3.7" "3.8" "3.9" "3.10")
 CUDA_OPTIONS=("none" "10.2" "11.1" "11.3" "11.6")
 CUDA="none"


### PR DESCRIPTION
Python 3.11 have been available for a while now. This patch enables support for 3.11 to be built where available.

cc @tqchen @areusch @Liam-Sturge for reviews