### PR TITLE
[AArch64] Update manylinux_aarch64 tag to 2023-03-12-25fd859

### DIFF
--- a/docker/Dockerfile.package-cpu_aarch64
+++ b/docker/Dockerfile.package-cpu_aarch64
@@ -1,6 +1,6 @@
 # Docker image: tlcpack/package-cpu_aarch64
 
-FROM quay.io/pypa/manylinux2014_aarch64:2022-07-27-a8099af
+FROM quay.io/pypa/manylinux2014_aarch64:2023-03-12-25fd859
 
 # install core
 COPY install/centos_install_core_aarch64.sh /install/centos_install_core_aarch64.sh
@@ -29,9 +29,10 @@ RUN bash /install/centos_install_arm_compute_library.sh
 
 # install python packages
 COPY install/centos_install_python_package.sh /install/centos_install_python_package.sh
-RUN bash /install/centos_install_python_package.sh 3.6
 RUN bash /install/centos_install_python_package.sh 3.7
 RUN bash /install/centos_install_python_package.sh 3.8
+RUN bash /install/centos_install_python_package.sh 3.9
+RUN bash /install/centos_install_python_package.sh 3.10
 
 COPY install/centos_install_auditwheel.sh /install/centos_install_auditwheel.sh
 RUN bash /install/centos_install_auditwheel.sh


### PR DESCRIPTION
* deprecate Python 3.6 support
* brings Python 3.11 support

Note: these changes were used to generate the current AArch64 at https://pypi.org/project/apache-tvm/0.11.1/#files

While we don't have (yet) an automated way to build and publish packages, we need to do the same manual process for x86 packaging and upload.

cc @tqchen @Liam-Sturge @areusch for reviews