### PR TITLE
[CI] Add new PyPI packaging Jenkins pipeline

### DIFF
--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -1,0 +1,282 @@
+#!groovy
+// -*- mode: groovy -*-
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+PACKAGE="pypi-nightly"
+PACKAGE_NAME="apache-tvm"
+CPU_IMAGE = "cpu:${params.TLCPACK_CPU_TAG}"
+AARCH64_IMAGE = "cpu_aarch64:${params.TLCPACK_AARCH64_TAG}"
+
+
+def cleanup_docker_image(image_type) {
+    // Delete images created/tagged by previous steps.
+    sh (
+        script: "docker rmi -f tlcpack/package-${image_type}",
+        label: "Cleanup ${image_type} image"
+    )
+}
+
+
+def clone_tlcpack() {
+    // clone tlcpack repo directly into Jenkins workspace
+    sh (
+        script: "git clone ${params.TLCPACK_GIT_REPO_URL} .",
+        label: "Clone tlcpack into Jenkins workspace",
+    )
+}
+
+
+def clone_tvm() {
+    sh (
+        script: "git clone ${params.TVM_GIT_REPO_URL} --recursive",
+        label: "Clone TVM in to /tvm directory",
+    )
+}
+
+
+def pull_docker_image(image_type) {
+    // The tag is expected to be passed as a Jenkins parameter
+    sh (
+        script: "docker pull tlcpack/package-${image_type}",
+        label: "Pull 'package-${image_type}' from Docker Hub",
+    )
+}
+
+
+def sync_package() {
+    sh (
+        script: """
+            python3 common/sync_package.py \
+              --cuda ${env.GPU} \
+              --package-name ${PACKAGE_NAME} \
+              --use-public-version \
+              ${PACKAGE}
+        """,
+        label: "Sync tlcpack package",
+    )
+}
+
+
+def build_wheels(image_type) {
+    sh (
+        script: """
+            ./docker/bash.sh --no-gpu tlcpack/package-${image_type} \
+                ./wheel/build_wheel_manylinux.sh --cuda ${env.GPU}
+        """,
+        label: "Build wheels on ${image_type}",
+    )
+}
+
+
+def test_wheels(image_type) {
+    sh (
+        script: """
+            ./docker/bash.sh --no-gpu tlcpack/package-${image_type} \
+                ./wheel/run_tests.sh
+        """,
+        label: "Test wheels for ${image_type}",
+    )
+}
+
+
+def upload_to_pypi() {
+    sh (
+        script: "sudo apt update && sudo apt install python3-pip --yes",
+        label: "Install python3-pip",
+    )
+    sh (
+        script: "python3 -m pip install twine",
+        label: "Install python package 'twine'",
+    )
+    sh (
+        script: "python3 -m twine upload tvm/python/repaired_wheels/*",
+        label: "Twine upload the repaired wheels to PyPI",
+    )
+}
+
+
+
+pipeline {
+    agent none
+
+    environment {
+        GPU = "none"
+        DISCORD_WEBHOOK = credentials("discord-webhook-url")
+        TWINE_NON_INTERACTIVE = 1
+        TWINE_REPOSITORY = "pypi"
+        TWINE_USERNAME = "__token__"
+        TWINE_PASSWORD = credentials("pypi-api-key")
+    }
+
+    options {
+        timeout(time: 1, unit: "HOURS")
+    }
+
+    parameters {
+        string(
+            name:"TLCPACK_GIT_REPO_URL",
+            defaultValue: "https://github.com/tlc-pack/tlcpack",
+            description: "URL for the tlcpack repository")
+        string(
+            name:"TLCPACK_CPU_TAG",
+            defaultValue: "2fddbe0",
+            description: "Tag for the Docker tlcpack CPU image")
+        string(
+            name:"TLCPACK_AARCH64_TAG",
+            defaultValue: "3e5b139d",
+            description: "Tag for the Docker tlcpack AArch64 image")
+        string(
+            name:"TVM_GIT_REV",
+            defaultValue: "main",
+            description: "Git revision to checkout.")
+        string(
+            name:"TVM_GIT_REPO_URL",
+            defaultValue: "https://github.com/apache/tvm",
+            description: "URL for the TVM repository")
+    }
+
+    stages {
+
+        stage("Setup workspace") {
+            agent {
+                node { label "CPU" }
+            }
+            steps {
+                cleanWs()
+                clone_tlcpack()
+                clone_tvm()
+                dir("tvm") {
+                    // Checkout the requested reference, so that we
+                    // can build images from branches/tags
+                    sh (
+                        script: "git checkout ${params.TVM_GIT_REV}",
+                        label: "Checkout requested reference",
+                    )
+                    script {
+                        TVM_CURRENT_SHORT_REF = sh (
+                            script: "git rev-parse --short HEAD",
+                            label: "Set current build display name",
+                            returnStdout: true
+                            ).trim()
+                        currentBuild.displayName = "tlcpack-${TVM_CURRENT_SHORT_REF}"
+                    } // script
+                } // dir(tvm)
+                sync_package()
+                stash (
+                    includes: "*/**",
+                    name: "tvm_workspace",
+                    allowEmpty: false,
+                )
+            }
+        } // stage(Setup workspace)
+
+        stage("Build and test wheels") {
+            parallel {
+
+                stage("CPU wheel") {
+                    agent {
+                        node { label "CPU" }
+                    }
+                    steps {
+                        cleanWs();
+                        unstash "tvm_workspace"
+                        script {
+                            pull_docker_image("${CPU_IMAGE}")
+                            build_wheels("${CPU_IMAGE}")
+                        } // script
+                        stash (
+                            includes: "tvm/python/repaired_wheels/**",
+                            name: "tvm_wheels_cpu",
+                            allowEmpty: false,
+                        )
+                    } // steps
+                } // stage(CPU wheel)
+
+                stage("arm wheel") {
+                    agent {
+                        node { label "ARM" }
+                    }
+                    steps {
+                        cleanWs();
+                        unstash "tvm_workspace"
+                        script {
+                            pull_docker_image("${AARCH64_IMAGE}")
+                            build_wheels("${AARCH64_IMAGE}")
+                        } //script
+                        stash (
+                            includes: "tvm/python/repaired_wheels/**",
+                            name: "tvm_wheels_aarch64",
+                            allowEmpty: false,
+                        )
+                    } // steps
+                } // stage(arm wheel)
+
+            } // parallel
+        } // stage: Build and test wheels
+
+        stage("upload wheels") {
+            when {
+                beforeAgent true
+                expression {
+                    echo "Deploy wheels to Pypi if Git revision is 'main'..."
+                    expression { return params.TVM_GIT_REV == 'main' }
+                }
+            }
+            agent {
+                node { label "CPU" }
+            }
+            steps {
+                cleanWs();
+                unstash "tvm_wheels_cpu"
+                unstash "tvm_wheels_aarch64"
+                sh (
+                    script: "find . -type f -name *.whl",
+                    label: "Find and list wheels",
+                )
+                upload_to_pypi()
+            }
+        }
+    } // stages
+
+    post {
+        success {
+            discordSend (
+                description: "New images published on PyPI: ${CPU_IMAGE}, ${AARCH64_IMAGE}.",
+                link: "https://pypi.org/project/apache-tvm/#history",
+                result: currentBuild.currentResult,
+                title: "${JOB_NAME}",
+                webhookURL: "${env.DISCORD_WEBHOOK}"
+            )
+        }
+        unsuccessful {
+            discordSend (
+                description: "Failed to generate tlcpack packages using TVM hash `${TVM_CURRENT_SHORT_REF}`. See logs at ${BUILD_URL}.",
+                link: "${BUILD_URL}",
+                result: currentBuild.currentResult,
+                title: "${JOB_NAME}",
+                webhookURL: "${env.DISCORD_WEBHOOK}"
+            )
+        }
+        always {
+            cleanup_docker_image("${AARCH64_IMAGE}")
+            cleanup_docker_image("${CPU_IMAGE}")
+            cleanWs();
+        }
+    } // post
+} // pipeline

--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -20,19 +20,14 @@
 
 PACKAGE="pypi-nightly"
 PACKAGE_NAME="apache-tvm"
-CPU_IMAGE = "cpu:${params.TLCPACK_CPU_TAG}"
 AARCH64_IMAGE = "cpu_aarch64:${params.TLCPACK_AARCH64_TAG}"
-
-s3_bucket = "tvm-jenkins-artifacts-prod"
-s3_prefix = "tvm/pypi-packaging/${env.BUILD_NUMBER}"
-jenkins_scripts_root = "ci/scripts/jenkins"
 
 
 def cleanup_docker_image(image_type) {
     // Delete images created/tagged by previous steps.
     sh (
         script: "docker rmi -f tlcpack/package-${image_type}",
-        label: "Cleanup ${image_type} image"
+        label: "Cleanup ${image_type} image",
     )
 }
 
@@ -54,70 +49,12 @@ def clone_tvm() {
 }
 
 
-def upload_s3_stash(stash_name) {
-    sh(
-        script: """
-            ./${jenkins_scripts_root}/s3.py \
-              --action upload \
-              --bucket ${s3_bucket} \
-              --prefix ${s3_prefix}/${stash_name} \
-              --items ${stash_name}.tar.gz
-
-            if [ "\$?" -eq 0 ]; then
-                printf "INFO: files were stashed with the name '%s'.\n", ${stash_name}
-            else
-                printf "WARN: 0 files were specified for the stash.\n"
-                exit 1
-            fi
-        """,
-        label: 'Upload artefacts to S3',
-    )
-}
-
-
-def download_s3_stash(stash_name) {
-    sh(
-        script: """
-            ./${jenkins_scripts_root}/s3.py \
-              --action download \
-              --bucket ${s3_bucket} \
-              --prefix ${s3_prefix}/${stash_name}
-
-            if [ "\$?" -eq 0 ]; then
-                printf "INFO: stash '%s' download complete.\n", ${stash_name}
-            else
-                printf "Error: unable to download stash '%s'.\n", ${stash_name}
-                exit 1
-            fi
-
-        """,
-        label: 'Download artefacts from S3',
-    )
-}
-
-
 def pull_docker_image(image_type) {
     // The tag is expected to be passed as a Jenkins parameter
     sh (
         script: "docker pull tlcpack/package-${image_type}",
         label: "Pull 'package-${image_type}' from Docker Hub",
     )
-}
-
-
-def setup_workspace_from_stash() {
-    clone_tvm()
-    dir("tvm") {
-        download_s3_stash("tvm_workspace")
-    }
-    sh (
-        script: """
-            mv tvm/tvm_workspace.tar.gz . &&
-            rm -rf tvm
-            tar -xvf tvm_workspace.tar.gz
-        """,
-        label: "untar stash 'tvm_workspace'",
-   )
 }
 
 
@@ -142,6 +79,14 @@ def build_wheels(image_type) {
                 ./wheel/build_wheel_manylinux.sh --cuda ${env.GPU}
         """,
         label: "Build wheels on ${image_type}",
+    )
+}
+
+
+def list_wheels() {
+    sh (
+        script: "find . -type f -name *.whl",
+        label: "Find and list wheels",
     )
 }
 
@@ -172,11 +117,7 @@ def upload_to_pypi() {
 
 pipeline {
 
-    agent {
-        node {
-            label 'CPU-SPOT'
-        }
-    }
+    agent { node { label 'ARM-SPOT' } }
 
     environment {
         GPU = "none"
@@ -197,10 +138,6 @@ pipeline {
             defaultValue: "https://github.com/tlc-pack/tlcpack",
             description: "URL for the tlcpack repository")
         string(
-            name:"TLCPACK_CPU_TAG",
-            defaultValue: "2fddbe0",
-            description: "Tag for the Docker tlcpack CPU image")
-        string(
             name:"TLCPACK_AARCH64_TAG",
             defaultValue: "3e5b139d",
             description: "Tag for the Docker tlcpack AArch64 image")
@@ -212,22 +149,11 @@ pipeline {
             name:"TVM_GIT_REPO_URL",
             defaultValue: "https://github.com/apache/tvm",
             description: "URL for the TVM repository")
-        booleanParam(
-            name:"BUILD_CPU",
-            defaultValue: false,
-            description: "Set to false if CPU packages are NOT required.")
-        booleanParam(
-            name:"BUILD_AARCH64",
-            defaultValue: true,
-            description: "Set to false if AArch64 packages are NOT required.")
     }
 
     stages {
 
-        stage("Setup workspace") {
-            agent {
-                node { label "CPU-SPOT" }
-            }
+        stage("Package AArch64") {
             steps {
                 cleanWs()
                 clone_tlcpack()
@@ -249,118 +175,20 @@ pipeline {
                     } // script
                 } // dir(tvm)
                 sync_package()
-                sh (
-                    script: """
-                        tar --exclude ./tvm_workspace.tar -cf tvm_workspace.tar . && gzip tvm_workspace.tar
-                        mv tvm_workspace.tar.gz tvm/
-                    """,
-                    label: "Tarball the workspace",
-                )
-                dir("tvm") {
-                    upload_s3_stash("tvm_workspace")
-                }
-            }
-        } // stage(Setup workspace)
-
-        stage("Build and test wheels") {
-            parallel {
-
-                stage("CPU wheel") {
-                    when {
-                        beforeAgent true
-                        expression { return params.BUILD_CPU }
-                    }
-                    agent {
-                        node { label "CPU-SPOT" }
-                    }
-                    steps {
-                        cleanWs();
-                        setup_workspace_from_stash()
-                        script {
-                            pull_docker_image("${CPU_IMAGE}")
-                            build_wheels("${CPU_IMAGE}")
-                            cleanup_docker_image("${CPU_IMAGE}")
-                        } // script
-                        dir("tvm") {
-                            sh (
-                                script: "tar -czf tvm_wheels_cpu.tar.gz python/repaired_wheels",
-                                label: "Tarball the workspace",
-                            )
-                            upload_s3_stash("tvm_wheels_cpu")
-                        }
-                    } // steps
-                } // stage(CPU wheel)
-
-                stage("AArch64 wheel") {
-                    when {
-                        beforeAgent true
-                        expression { return params.BUILD_AARCH64 }
-                    }
-                    agent {
-                        node { label "ARM-SPOT" }
-                    }
-                    steps {
-                        cleanWs();
-                        setup_workspace_from_stash()
-                        script {
-                            pull_docker_image("${AARCH64_IMAGE}")
-                            build_wheels("${AARCH64_IMAGE}")
-                            cleanup_docker_image("${AARCH64_IMAGE}")
-                        } //script
-                        dir("tvm") {
-                            sh (
-                                script: "tar -czf tvm_wheels_aarch64.tar.gz python/repaired_wheels",
-                                label: "Tarball the workspace",
-                            )
-                            upload_s3_stash("tvm_wheels_aarch64")
-                        }
-                    } // steps
-                } // stage(arm wheel)
-
-            } // parallel
-        } // stage: Build and test wheels
-
-        stage("upload wheels") {
-            when {
-                beforeAgent true
-                expression {
-                    echo "Deploy wheels to Pypi if Git revision is 'main'..."
-                    expression { return params.TVM_GIT_REV == 'main' }
-                }
-            }
-            agent {
-                node { label "CPU-SPOT" }
-            }
-            steps {
-                cleanWs();
-                setup_workspace_from_stash()
-                dir("tvm") {
-                    script {
-                        if (params.BUILD_CPU) {
-                            download_s3_stash("tvm_wheels_cpu")
-                            sh "tar -xvf tvm_wheels_cpu.tar.gz --skip-old-files"
-                        }
-                    }
-                    script {
-                        if (params.BUILD_AARCH64) {
-                            download_s3_stash("tvm_wheels_aarch64")
-                            sh "tar -xvf tvm_wheels_aarch64.tar.gz --skip-old-files"
-                        }
-                    }
-                }
-                sh (
-                    script: "find . -type f -name *.whl",
-                    label: "Find and list wheels",
-                )
+                pull_docker_image("${AARCH64_IMAGE}")
+                build_wheels("${AARCH64_IMAGE}")
+                cleanup_docker_image("${AARCH64_IMAGE}")
+                list_wheels()
                 upload_to_pypi()
             }
-        }
+        } // stage(Package AArch64)
+
     } // stages
 
     post {
         success {
             discordSend (
-                description: "New packages published on PyPI.",
+                description: "New packages published on PyPI for ${AARCH64_IMAGE}.",
                 link: "https://pypi.org/project/apache-tvm/#history",
                 result: currentBuild.currentResult,
                 title: "${JOB_NAME}",

--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -113,7 +113,7 @@ def upload_to_pypi() {
 
 
 pipeline {
-    agent none
+    agent any
 
     environment {
         GPU = "none"
@@ -199,6 +199,7 @@ pipeline {
                         script {
                             pull_docker_image("${CPU_IMAGE}")
                             build_wheels("${CPU_IMAGE}")
+                            cleanup_docker_image("${CPU_IMAGE}")
                         } // script
                         stash (
                             includes: "tvm/python/repaired_wheels/**",
@@ -208,7 +209,7 @@ pipeline {
                     } // steps
                 } // stage(CPU wheel)
 
-                stage("arm wheel") {
+                stage("AArch64 wheel") {
                     agent {
                         node { label "ARM" }
                     }
@@ -218,6 +219,7 @@ pipeline {
                         script {
                             pull_docker_image("${AARCH64_IMAGE}")
                             build_wheels("${AARCH64_IMAGE}")
+                            cleanup_docker_image("${AARCH64_IMAGE}")
                         } //script
                         stash (
                             includes: "tvm/python/repaired_wheels/**",
@@ -257,7 +259,7 @@ pipeline {
     post {
         success {
             discordSend (
-                description: "New images published on PyPI: ${CPU_IMAGE}, ${AARCH64_IMAGE}.",
+                description: "New images published on PyPI: ${AARCH64_IMAGE}, ${CPU_IMAGE}.",
                 link: "https://pypi.org/project/apache-tvm/#history",
                 result: currentBuild.currentResult,
                 title: "${JOB_NAME}",
@@ -273,9 +275,7 @@ pipeline {
                 webhookURL: "${env.DISCORD_WEBHOOK}"
             )
         }
-        always {
-            cleanup_docker_image("${AARCH64_IMAGE}")
-            cleanup_docker_image("${CPU_IMAGE}")
+        cleanup {
             cleanWs();
         }
     } // post

--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -23,6 +23,10 @@ PACKAGE_NAME="apache-tvm"
 CPU_IMAGE = "cpu:${params.TLCPACK_CPU_TAG}"
 AARCH64_IMAGE = "cpu_aarch64:${params.TLCPACK_AARCH64_TAG}"
 
+s3_bucket = "tvm-jenkins-artifacts-prod"
+s3_prefix = "tvm/pypi-packaging/${env.BUILD_NUMBER}"
+jenkins_scripts_root = "ci/scripts/jenkins"
+
 
 def cleanup_docker_image(image_type) {
     // Delete images created/tagged by previous steps.
@@ -50,12 +54,70 @@ def clone_tvm() {
 }
 
 
+def upload_s3_stash(stash_name) {
+    sh(
+        script: """
+            ./${jenkins_scripts_root}/s3.py \
+              --action upload \
+              --bucket ${s3_bucket} \
+              --prefix ${s3_prefix}/${stash_name} \
+              --items ${stash_name}.tar.gz
+
+            if [ "\$?" -eq 0 ]; then
+                printf "INFO: files were stashed with the name '%s'.\n", ${stash_name}
+            else
+                printf "WARN: 0 files were specified for the stash.\n"
+                exit 1
+            fi
+        """,
+        label: 'Upload artefacts to S3',
+    )
+}
+
+
+def download_s3_stash(stash_name) {
+    sh(
+        script: """
+            ./${jenkins_scripts_root}/s3.py \
+              --action download \
+              --bucket ${s3_bucket} \
+              --prefix ${s3_prefix}/${stash_name}
+
+            if [ "\$?" -eq 0 ]; then
+                printf "INFO: stash '%s' download complete.\n", ${stash_name}
+            else
+                printf "Error: unable to download stash '%s'.\n", ${stash_name}
+                exit 1
+            fi
+
+        """,
+        label: 'Download artefacts from S3',
+    )
+}
+
+
 def pull_docker_image(image_type) {
     // The tag is expected to be passed as a Jenkins parameter
     sh (
         script: "docker pull tlcpack/package-${image_type}",
         label: "Pull 'package-${image_type}' from Docker Hub",
     )
+}
+
+
+def setup_workspace_from_stash() {
+    clone_tvm()
+    dir("tvm") {
+        download_s3_stash("tvm_workspace")
+    }
+    sh (
+        script: """
+            mv tvm/tvm_workspace.tar.gz . &&
+            rm -rf tvm
+            tar -xvf tvm_workspace.tar.gz
+        """,
+        label: "untar stash 'tvm_workspace'",
+   )
 }
 
 
@@ -164,7 +226,7 @@ pipeline {
 
         stage("Setup workspace") {
             agent {
-                node { label "CPU" }
+                node { label "CPU-SPOT" }
             }
             steps {
                 cleanWs()
@@ -187,11 +249,16 @@ pipeline {
                     } // script
                 } // dir(tvm)
                 sync_package()
-                stash (
-                    includes: "*/**",
-                    name: "tvm_workspace",
-                    allowEmpty: false,
+                sh (
+                    script: """
+                        tar --exclude ./tvm_workspace.tar -cf tvm_workspace.tar . && gzip tvm_workspace.tar
+                        mv tvm_workspace.tar.gz tvm/
+                    """,
+                    label: "Tarball the workspace",
                 )
+                dir("tvm") {
+                    upload_s3_stash("tvm_workspace")
+                }
             }
         } // stage(Setup workspace)
 
@@ -204,21 +271,23 @@ pipeline {
                         expression { return params.BUILD_CPU }
                     }
                     agent {
-                        node { label "CPU" }
+                        node { label "CPU-SPOT" }
                     }
                     steps {
                         cleanWs();
-                        unstash "tvm_workspace"
+                        setup_workspace_from_stash()
                         script {
                             pull_docker_image("${CPU_IMAGE}")
                             build_wheels("${CPU_IMAGE}")
                             cleanup_docker_image("${CPU_IMAGE}")
                         } // script
-                        stash (
-                            includes: "tvm/python/repaired_wheels/**",
-                            name: "tvm_wheels_cpu",
-                            allowEmpty: false,
-                        )
+                        dir("tvm") {
+                            sh (
+                                script: "tar -czf tvm_wheels_cpu.tar.gz python/repaired_wheels",
+                                label: "Tarball the workspace",
+                            )
+                            upload_s3_stash("tvm_wheels_cpu")
+                        }
                     } // steps
                 } // stage(CPU wheel)
 
@@ -228,21 +297,23 @@ pipeline {
                         expression { return params.BUILD_AARCH64 }
                     }
                     agent {
-                        node { label "ARM" }
+                        node { label "ARM-SPOT" }
                     }
                     steps {
                         cleanWs();
-                        unstash "tvm_workspace"
+                        setup_workspace_from_stash()
                         script {
                             pull_docker_image("${AARCH64_IMAGE}")
                             build_wheels("${AARCH64_IMAGE}")
                             cleanup_docker_image("${AARCH64_IMAGE}")
                         } //script
-                        stash (
-                            includes: "tvm/python/repaired_wheels/**",
-                            name: "tvm_wheels_aarch64",
-                            allowEmpty: false,
-                        )
+                        dir("tvm") {
+                            sh (
+                                script: "tar -czf tvm_wheels_aarch64.tar.gz python/repaired_wheels",
+                                label: "Tarball the workspace",
+                            )
+                            upload_s3_stash("tvm_wheels_aarch64")
+                        }
                     } // steps
                 } // stage(arm wheel)
 
@@ -258,12 +329,25 @@ pipeline {
                 }
             }
             agent {
-                node { label "CPU" }
+                node { label "CPU-SPOT" }
             }
             steps {
                 cleanWs();
-                unstash "tvm_wheels_cpu"
-                unstash "tvm_wheels_aarch64"
+                setup_workspace_from_stash()
+                dir("tvm") {
+                    script {
+                        if (params.BUILD_CPU) {
+                            download_s3_stash("tvm_wheels_cpu")
+                            sh "tar -xvf tvm_wheels_cpu.tar.gz --skip-old-files"
+                        }
+                    }
+                    script {
+                        if (params.BUILD_AARCH64) {
+                            download_s3_stash("tvm_wheels_aarch64")
+                            sh "tar -xvf tvm_wheels_aarch64.tar.gz --skip-old-files"
+                        }
+                    }
+                }
                 sh (
                     script: "find . -type f -name *.whl",
                     label: "Find and list wheels",

--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -97,10 +97,6 @@ def test_wheels(image_type) {
 
 def upload_to_pypi() {
     sh (
-        script: "sudo apt update && sudo apt install python3-pip --yes",
-        label: "Install python3-pip",
-    )
-    sh (
         script: "python3 -m pip install twine",
         label: "Install python package 'twine'",
     )

--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -109,7 +109,12 @@ def upload_to_pypi() {
 
 
 pipeline {
-    agent any
+
+    agent {
+        node {
+            label 'CPU-SPOT'
+        }
+    }
 
     environment {
         GPU = "none"
@@ -145,6 +150,14 @@ pipeline {
             name:"TVM_GIT_REPO_URL",
             defaultValue: "https://github.com/apache/tvm",
             description: "URL for the TVM repository")
+        booleanParam(
+            name:"BUILD_CPU",
+            defaultValue: false,
+            description: "Set to false if CPU packages are NOT required.")
+        booleanParam(
+            name:"BUILD_AARCH64",
+            defaultValue: true,
+            description: "Set to false if AArch64 packages are NOT required.")
     }
 
     stages {
@@ -186,6 +199,10 @@ pipeline {
             parallel {
 
                 stage("CPU wheel") {
+                    when {
+                        beforeAgent true
+                        expression { return params.BUILD_CPU }
+                    }
                     agent {
                         node { label "CPU" }
                     }
@@ -206,6 +223,10 @@ pipeline {
                 } // stage(CPU wheel)
 
                 stage("AArch64 wheel") {
+                    when {
+                        beforeAgent true
+                        expression { return params.BUILD_AARCH64 }
+                    }
                     agent {
                         node { label "ARM" }
                     }
@@ -255,7 +276,7 @@ pipeline {
     post {
         success {
             discordSend (
-                description: "New images published on PyPI: ${AARCH64_IMAGE}, ${CPU_IMAGE}.",
+                description: "New packages published on PyPI.",
                 link: "https://pypi.org/project/apache-tvm/#history",
                 result: currentBuild.currentResult,
                 title: "${JOB_NAME}",


### PR DESCRIPTION
This patch adds a new Jenkins pipeline for packaging. This is a migration of the current Github actions workflow of uploading a Tensor learning compiler binary distribution (tlcpack) to PyPI.

This new packaging pipeline implements a parallel step that creates and uploads AArch64 packages, which is something not present in the Github actions job it is intended to replace.

I have tested the pipeline [here](https://ci.tlcpack.ai/blue/organizations/jenkins/pypi-packaging%2Fregular-pypi-package-upload/detail/regular-pypi-package-upload/4/pipeline), with some minor modifications so that the packages were uploaded to my personal test.pypi account. The code submitted in this patch will attempt to upload to the apache-tvm production package.

cc @areusch @driazati @tqchen @leandron 