### PR TITLE
[LLVM] Update LLVM from 10.0.x to 15.0.x

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cpu_aarch64
+++ b/docker/Dockerfile.package-cpu_aarch64
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cu102
+++ b/docker/Dockerfile.package-cu102
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cu110
+++ b/docker/Dockerfile.package-cu110
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cu111
+++ b/docker/Dockerfile.package-cu111
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cu113
+++ b/docker/Dockerfile.package-cu113
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cu116
+++ b/docker/Dockerfile.package-cu116
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 10.0
+RUN bash /install/centos_build_llvm.sh 15.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/install/centos_build_llvm.sh
+++ b/docker/install/centos_build_llvm.sh
@@ -17,16 +17,20 @@ detect_llvm_version() {
 
 LLVM_VERSION=$(detect_llvm_version)
 echo ${LLVM_VERSION}
-curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz -o llvm-${LLVM_VERSION}.src.tar.xz
-unxz llvm-${LLVM_VERSION}.src.tar.xz
-tar xf llvm-${LLVM_VERSION}.src.tar
-pushd llvm-${LLVM_VERSION}.src
+# LLVM
+curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz -o llvm-project-${LLVM_VERSION}.src.tar.xz
+unxz llvm-project-${LLVM_VERSION}.src.tar.xz
+tar xf llvm-project-${LLVM_VERSION}.src.tar
+pushd llvm-project-${LLVM_VERSION}.src
+
+pushd llvm
 mkdir build
 pushd build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
+    -DLLVM_INCLUDE_BENCHMARKS=OFF \
     -DLLVM_INCLUDE_DOCS=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_INCLUDE_TESTS=OFF \
@@ -36,39 +40,39 @@ cmake \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_ENABLE_OCAMLDOC=OFF \
     -DLLVM_USE_INTEL_JITEVENTS=ON \
-    -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
-    -DPYTHON_EXECUTABLE="$(cpython_path 3.7)/bin/python" \
+    -DPYTHON_EXECUTABLE="$(cpython_path 3.8)/bin/python" \
     -GNinja \
     ..
 ninja install
 popd
 popd
-rm -rf llvm-${LLVM_VERSION}.src.tar.xz llvm-${LLVM_VERSION}.src.tar llvm-${LLVM_VERSION}.src
-
 
 # clang is only used to precompile Gandiva bitcode
-if [ ${LLVM_VERSION_MAJOR} -lt 9 ]; then
+if [ "${LLVM_VERSION_MAJOR}" -lt 9 ]; then
   clang_package_name=cfe
 else
   clang_package_name=clang
 fi
-curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${clang_package_name}-${LLVM_VERSION}.src.tar.xz -o ${clang_package_name}-${LLVM_VERSION}.src.tar.xz
-unxz ${clang_package_name}-${LLVM_VERSION}.src.tar.xz
-tar xf ${clang_package_name}-${LLVM_VERSION}.src.tar
-pushd ${clang_package_name}-${LLVM_VERSION}.src
+
+pushd ${clang_package_name}
 mkdir build
 pushd build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_MODULE_PATH="/llvm-project-${LLVM_VERSION}.src/cmake/Modules" \
     -DCLANG_INCLUDE_TESTS=OFF \
     -DCLANG_INCLUDE_DOCS=OFF \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_INCLUDE_DOCS=OFF \
-    -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+    -DLLVM_ENABLE_LIBEDIT=OFF \
+    -Wno-dev \
     -GNinja \
     ..
 ninja -w dupbuild=warn install # both clang and llvm builds generate llvm-config file
 popd
 popd
-rm -rf ${clang_package_name}-${LLVM_VERSION}.src.tar.xz ${clang_package_name}-${LLVM_VERSION}.src.tar ${clang_package_name}-${LLVM_VERSION}.src
+
+popd
+
+rm -rf llvm-project-${LLVM_VERSION}.src.tar.xz llvm-project-${LLVM_VERSION}.src.tar


### PR DESCRIPTION
Update LLVM version from 10.0.x to align with the currently used in TVM, which is 15.0.x (specifically 15.0.7 at the time this PR was raised) so that we can have feature parity with TVM built from source and TVM in packages.

This is a required counterpart change as we moved to LLVM in TVM.

cc @areusch @Liam-Sturge @neildhickey @NicolaLancellotti for reviews