### PR TITLE
[CI] Fix PyPI api token

### DIFF
--- a/jenkins/JenkinsFile-PyPI-packaging
+++ b/jenkins/JenkinsFile-PyPI-packaging
@@ -125,7 +125,7 @@ pipeline {
         TWINE_NON_INTERACTIVE = 1
         TWINE_REPOSITORY = "pypi"
         TWINE_USERNAME = "__token__"
-        TWINE_PASSWORD = credentials("pypi-api-key")
+        TWINE_PASSWORD = credentials("pypi-api-token")
     }
 
     options {


### PR DESCRIPTION
Token is stored under a different name in Jenkins. Updating the script to match.

cc @leandron @areusch @tqchen @Mousius 