### PR TITLE
Cut daily Docker image validate trigger from Jenkins pipeline

### DIFF
--- a/jenkins/JenkinsFile-rebuild-docker-images
+++ b/jenkins/JenkinsFile-rebuild-docker-images
@@ -377,14 +377,6 @@ pipeline {
   post {
     success {
 
-      // When the build is successful, trigger a validation build, using the tag just produced.
-      build job: 'daily-docker-image-validate',
-        wait: false,
-        propagate: false,
-        parameters: [
-          [$class: 'StringParameterValue', name: 'tlcpack_staging_tag', value: "${TVM_DOCKER_TAG}"]
-        ]
-
       discordSend description: "New images published on DockerHub with tag `${TVM_DOCKER_TAG}`. Use `docker pull tlcpackstaging/<image_type>:${TVM_DOCKER_TAG}` to download the images. Image types: `ci_arm`, `ci_cpu`, `ci_minimal`, `ci_gpu`, `ci_i386`, `ci_lint`, `ci_cortexm`, `ci_wasm`, `ci_hexagon`, `ci_riscv`.",
         link: "https://hub.docker.com/u/tlcpackstaging/",
         result: currentBuild.currentResult,


### PR DESCRIPTION
Since work was completed to split up Jenkins in to platform-specific jobs (PR: https://github.com/apache/tvm/pull/13316), the pipeline for validating the docker images with tests has been failing.

It doesn't appear this validation pipeline is still needed. We can disable it to save on compute resources, however in doing so, it causes a failure of the `daily-docker-image-rebuild` pipeline, which triggers the validation pipeline to be run if the build is successful. This is because the validation pipeline relied on the file `JenkinsFile`, which was removed as part of the changes mentioned above.

In order to resolve the build errors for the daily docker rebuild, it is necessary to remove the trigger for the validation pipeline.

cc @areusch @konturn @Mousius @leandron @tqchen 