### PR TITLE
[LLVM] Update LLVM from 15.0.x to 16.0.x

### DIFF
--- a/docker/Dockerfile.package-cpu
+++ b/docker/Dockerfile.package-cpu
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 15.0
+RUN bash /install/centos_build_llvm.sh 16.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/Dockerfile.package-cpu_aarch64
+++ b/docker/Dockerfile.package-cpu_aarch64
@@ -12,7 +12,7 @@ RUN bash /install/centos_install_cmake.sh
 
 # build llvm
 COPY install/centos_build_llvm.sh /install/centos_build_llvm.sh
-RUN bash /install/centos_build_llvm.sh 15.0
+RUN bash /install/centos_build_llvm.sh 16.0
 
 # upgrade patchelf due to the bug in patchelf 0.10
 # see details at https://stackoverflow.com/questions/61007071/auditwheel-repair-not-working-as-expected

--- a/docker/install/centos_build_llvm.sh
+++ b/docker/install/centos_build_llvm.sh
@@ -23,13 +23,13 @@ unxz llvm-project-${LLVM_VERSION}.src.tar.xz
 tar xf llvm-project-${LLVM_VERSION}.src.tar
 pushd llvm-project-${LLVM_VERSION}.src
 
-pushd llvm
 mkdir build
 pushd build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
+    -DLLVM_ENABLE_PROJECTS="clang" \
     -DLLVM_INCLUDE_BENCHMARKS=OFF \
     -DLLVM_INCLUDE_DOCS=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
@@ -39,40 +39,12 @@ cmake \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_ENABLE_OCAMLDOC=OFF \
+    -DLLVM_ENABLE_PLUGINS=ON \
     -DLLVM_USE_INTEL_JITEVENTS=ON \
-    -DPYTHON_EXECUTABLE="$(cpython_path 3.8)/bin/python" \
     -GNinja \
-    ..
+    ../llvm
 ninja install
 popd
-popd
-
-# clang is only used to precompile Gandiva bitcode
-if [ "${LLVM_VERSION_MAJOR}" -lt 9 ]; then
-  clang_package_name=cfe
-else
-  clang_package_name=clang
-fi
-
-pushd ${clang_package_name}
-mkdir build
-pushd build
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_MODULE_PATH="/llvm-project-${LLVM_VERSION}.src/cmake/Modules" \
-    -DCLANG_INCLUDE_TESTS=OFF \
-    -DCLANG_INCLUDE_DOCS=OFF \
-    -DLLVM_INCLUDE_TESTS=OFF \
-    -DLLVM_INCLUDE_DOCS=OFF \
-    -DLLVM_ENABLE_LIBEDIT=OFF \
-    -Wno-dev \
-    -GNinja \
-    ..
-ninja -w dupbuild=warn install # both clang and llvm builds generate llvm-config file
-popd
-popd
-
 popd
 
 rm -rf llvm-project-${LLVM_VERSION}.src.tar.xz llvm-project-${LLVM_VERSION}.src.tar


### PR DESCRIPTION
Align the LLVM version with main TVM repository, so that packages contain the same level of functionality as building from source.

Simplify the script build clang and LLVM as part of a one step build, as recommended by the official clang docs at https://clang.llvm.org/get_started.html

Updates validated in both CPU images.


cc @tqchen @areusch @Liam-Sturge @ashutosh-arm @neildhickey