### PR TITLE
[ACL] Update Compute Library to v23.05

### DIFF
--- a/docker/install/centos_install_arm_compute_library.sh
+++ b/docker/install/centos_install_arm_compute_library.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-compute_lib_version="v23.02.1"
+compute_lib_version="v23.05"
 compute_lib_variant="arm64-v8a-neon"
 compute_lib_full_name="arm_compute-${compute_lib_version}-bin-linux-${compute_lib_variant}"
 compute_lib_base_url="https://github.com/ARM-software/ComputeLibrary/releases/download/${compute_lib_version}"


### PR DESCRIPTION
Update Compute Library to follow latest developments in 23.05.
Changelog: https://arm-software.github.io/ComputeLibrary/v23.05

Counterpart change in TVM at https://github.com/apache/tvm/pull/15344

cc @neildhickey @ashutosh-arm @lhutton1 for reviews