### PR TITLE
Pin Cython version to fix Cython compilation

### DIFF
--- a/.github/workflows/conda_cpu_nigthly.yaml
+++ b/.github/workflows/conda_cpu_nigthly.yaml
@@ -56,7 +56,7 @@ jobs:
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}
       env:
-         MACOSX_DEPLOYMENT_TARGET: 10.15
+         MACOSX_DEPLOYMENT_TARGET: 11.7
       run: >-
         conda build --output-folder=conda/pkg -m conda/build_config.yaml conda/recipe
     - name: Conda-Build@Linux

--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -54,7 +54,7 @@ jobs:
       run: >-
         wheel/build_lib_osx.sh
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.15
+        MACOSX_DEPLOYMENT_TARGET: 11.7
     - name: Build@Win
       if: startsWith(matrix.os, 'windows')
       shell: cmd /C call {0}
@@ -66,9 +66,9 @@ jobs:
         python-version: 3.7
     - name: Wheel-Build@Py37
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.15
+        MACOSX_DEPLOYMENT_TARGET: 11.7
       run: |
-        python -m pip install setuptools Cython wheel
+        python -m pip install setuptools Cython==0.29.34 wheel
         cd tvm/python
         python setup.py bdist_wheel
     - uses: actions/setup-python@v2
@@ -76,9 +76,9 @@ jobs:
         python-version: 3.8
     - name: Wheel-Build@Py38
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.15
+        MACOSX_DEPLOYMENT_TARGET: 11.7
       run: |
-        python -m pip install setuptools Cython wheel
+        python -m pip install setuptools Cython==0.29.34 wheel
         cd tvm/python
         python setup.py bdist_wheel
     # Use system python instead of conda for upload

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - anaconda-client
   - git
   - llvmdev ==10.0.0
-  - numpy
+  - numpy >=1.17
   - pytest
   - cmake
   - bzip2

--- a/conda/recipe/conda_build_config.yaml
+++ b/conda/recipe/conda_build_config.yaml
@@ -5,3 +5,6 @@ python:
 
 cuda:
   - False
+
+numpy:
+  - 1.17

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -60,7 +60,7 @@ outputs:
       host:
         - python
         - setuptools
-        - cython
+        - cython >=0.29.34
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
       run:
         - python

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -68,7 +68,7 @@ outputs:
         - psutil
         - scipy
         - pytest
-        - {{ pin_compatible('numpy') }}
+        - {{ pin_compatible('numpy', lower_bound='1.17', max_pin='x.x') }}
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
 
 about:

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -61,6 +61,7 @@ outputs:
         - python
         - setuptools
         - cython >=0.29.34
+        - {{ pin_compatible('numpy', lower_bound='1.17', max_pin='x.x') }}
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
       run:
         - python

--- a/docker/install/centos_install_python_package.sh
+++ b/docker/install/centos_install_python_package.sh
@@ -6,7 +6,7 @@ source /multibuild/manylinux_utils.sh
 
 eval "$(conda shell.bash hook)"
 
-PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
+PYTHON_PACKAGES="six numpy pytest cython==0.29.34 decorator scipy tornado typed_ast mypy \
 orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 for env in $(conda env list | grep py | awk '{print $1}'); do

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
+PYTHON_PACKAGES="six numpy pytest cython==0.29.34 decorator scipy tornado typed_ast mypy \
 orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 # install libraries for python package on ubuntu


### PR DESCRIPTION
Cython 3.0.0 was recently released, but it is incompatible with the current .pxi definitions in python/tvm/_ffi/_cpython.

Cython has been pinned for TVM in PR: [15353](https://github.com/apache/tvm/pull/15353) until a working fix is created. This patch replicates many of the changes for TLCPack installation, as we are seeing the same Cython errors when trying to use TLCPack Ubuntu Docker images.