### PR TITLE
[CI] Pin Cython to fix compilation error

### DIFF
--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -68,7 +68,7 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.15
       run: |
-        python -m pip install setuptools Cython wheel
+        python -m pip install setuptools Cython==0.29.34 wheel
         cd tvm/python
         python setup.py bdist_wheel
     - uses: actions/setup-python@v2
@@ -78,7 +78,7 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.15
       run: |
-        python -m pip install setuptools Cython wheel
+        python -m pip install setuptools Cython==0.29.34 wheel
         cd tvm/python
         python setup.py bdist_wheel
     # Use system python instead of conda for upload

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -60,7 +60,7 @@ outputs:
       host:
         - python
         - setuptools
-        - cython
+        - cython ==0.29.34
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
       run:
         - python

--- a/conda/recipe/meta.in.yaml
+++ b/conda/recipe/meta.in.yaml
@@ -60,7 +60,7 @@ outputs:
       host:
         - python
         - setuptools
-        - cython ==0.29.34
+        - cython
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
       run:
         - python

--- a/docker/install/centos_install_python_package.sh
+++ b/docker/install/centos_install_python_package.sh
@@ -6,7 +6,7 @@ source /multibuild/manylinux_utils.sh
 
 eval "$(conda shell.bash hook)"
 
-PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
+PYTHON_PACKAGES="six numpy pytest cython==0.29.34 decorator scipy tornado typed_ast mypy \
 orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 for env in $(conda env list | grep py | awk '{print $1}'); do

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-PYTHON_PACKAGES="six numpy pytest cython decorator scipy tornado typed_ast mypy \
+PYTHON_PACKAGES="six numpy pytest cython==0.29.34 decorator scipy tornado typed_ast mypy \
 orderedset antlr4-python3-runtime attrs requests Pillow packaging junitparser synr cloudpickle xgboost==1.5.0"
 
 # install libraries for python package on ubuntu


### PR DESCRIPTION
Cython 3.0.0 was recently released, but it is incompatible with the current .pxi definitions in python/tvm/_ffi/_cpython.

Cython has been pinned for TVM in PR: [15353](https://github.com/apache/tvm/pull/15353) until a working fix is created. This patch replicates many of the changes for TLCPack installation, as we are seeing the same Cython errors when trying to use TLCPack Ubuntu Docker images.

cc @leandron @areusch @konturn @Mousius @lhutton1 @tqchen