### PR TITLE
Optimize setting LLVM version for TLCPack

### DIFF
--- a/docker/install/centos_build_llvm.sh
+++ b/docker/install/centos_build_llvm.sh
@@ -7,12 +7,10 @@ LLVM_VERSION_MAJOR=$1
 source /multibuild/manylinux_utils.sh
 
 detect_llvm_version() {
-  curl -sL "https://api.github.com/repos/llvm/llvm-project/releases?per_page=100" | \
-    grep tag_name | \
-    grep -o "llvmorg-${LLVM_VERSION_MAJOR}[^\"]*" | \
-    grep -v rc | \
-    sed -e "s/^llvmorg-//g" | \
-    head -n 1
+  git ls-remote --sort='v:refname' --tags --refs 'https://github.com/llvm/llvm-project' | \
+     grep "llvmorg-${LLVM_VERSION_MAJOR}" | \
+     grep -v 'rc' | \
+     awk 'BEGIN { FS="-" } END {print $2}'
 }
 
 LLVM_VERSION=$(detect_llvm_version)


### PR DESCRIPTION
This change fixes issue https://github.com/tlc-pack/tlcpack/issues/190

Changes the script `centos_build_llvm.sh` to discover what tags are available in the LLVM project using `git ls-remote`. This is a more efficient approach, as it doesn't use the Github API and therefore isn't impacted by API rate limits, which will prevent the script from working correctly. The end result is the same and retrieves the latest semantic version for LLVM in the format XX.X.XX, e.g. 16.0.6.

CC @leandron @lhutton1